### PR TITLE
Footer Option and newEmail Method Enhancement 

### DIFF
--- a/core/src/main/java/org/fenixedu/messaging/ui/EmailBean.java
+++ b/core/src/main/java/org/fenixedu/messaging/ui/EmailBean.java
@@ -55,6 +55,7 @@ import com.google.common.base.Strings;
 public class EmailBean implements Serializable {
     private static final long serialVersionUID = -2004655177098978589L;
 
+    private boolean automaticFooter = true;
     private Sender sender;
     private List<Group> recipients = new ArrayList<>();
     private String tos, ccs, bccs;
@@ -71,6 +72,14 @@ public class EmailBean implements Serializable {
         this.htmlMessage = message.getHtmlBody();
         this.bccs = message.getExtraBccs();
         this.createdDate = message.getCreated();
+    }
+
+    public boolean isAutomaticFooter() {
+        return automaticFooter;
+    }
+
+    public void setAutomaticFooter(boolean automaticFooter) {
+        this.automaticFooter = automaticFooter;
     }
 
     public Sender getSender() {
@@ -188,10 +197,14 @@ public class EmailBean implements Serializable {
     public Message send() {
         String fullBody = null;
         if (!Strings.isNullOrEmpty(getMessage())) {
-            fullBody =
-                    BundleUtil.getString("resources.MessagingResources", "message.email.footer", getMessage(), getSender()
-                            .getFromName(),
-                            getRecipients().stream().map(r -> r.getPresentationName()).collect(Collectors.joining("\n\t")));
+            if(isAutomaticFooter()) {
+                fullBody =
+                        BundleUtil.getString("resources.MessagingResources", "message.email.footer", getMessage(), getSender()
+                                .getFromName(),
+                                getRecipients().stream().map(r -> r.getPresentationName()).collect(Collectors.joining("\n\t")));
+            } else {
+                fullBody = getMessage();
+            }
         }
         MessageBuilder builder = getSender().message(getSubject(), fullBody);
         if (!Strings.isNullOrEmpty(htmlMessage)) {

--- a/core/src/main/java/org/fenixedu/messaging/ui/MessagingAction.java
+++ b/core/src/main/java/org/fenixedu/messaging/ui/MessagingAction.java
@@ -24,9 +24,12 @@
  */
 package org.fenixedu.messaging.ui;
 
+import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -34,6 +37,8 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
+import org.fenixedu.bennu.core.domain.groups.PersistentGroup;
+import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.struts.annotations.Mapping;
 import org.fenixedu.bennu.struts.base.BaseAction;
 import org.fenixedu.bennu.struts.portal.EntryPoint;
@@ -44,6 +49,7 @@ import org.fenixedu.messaging.domain.Message;
 import org.fenixedu.messaging.domain.Sender;
 
 import pt.ist.fenixWebFramework.renderers.utils.RenderUtils;
+import pt.ist.fenixframework.FenixFramework;
 
 /**
  *
@@ -86,6 +92,11 @@ public class MessagingAction extends BaseAction {
         if (emailBean == null) {
             emailBean = new EmailBean();
 
+            Boolean automaticFooter = (Boolean) request.getAttribute("automaticFooter");
+            if (automaticFooter != null) {
+                emailBean.setAutomaticFooter(automaticFooter);
+            }
+
             final Sender sender = getDomainObject(request, "senderId");
             if (sender != null) {
                 emailBean.setSender(sender);
@@ -95,6 +106,16 @@ public class MessagingAction extends BaseAction {
                     emailBean.setSender(availableSenders.iterator().next());
                 }
             }
+
+            String[] recipientsParameter = request.getParameterValues("recipientIds");
+            if (recipientsParameter != null) {
+                List<Group> recipients =
+                        Stream.of(recipientsParameter)
+                                .map(recipientExternalId -> ((PersistentGroup) FenixFramework
+                                        .getDomainObject(recipientExternalId)).toGroup()).collect(Collectors.toList());
+                emailBean.setRecipients(recipients);
+            }
+
         }
         RenderUtils.invalidateViewState();
 


### PR DESCRIPTION
Made the footer detailing recipients optional through an EmailBean attribute
This option can be specified via request parameters in MessagingAction's newEmail method
In the same way it is now possible to specify the message recipients as well