### PR TITLE
Localize Message Content

### DIFF
--- a/core/src/main/dml/messaging.dml
+++ b/core/src/main/dml/messaging.dml
@@ -26,9 +26,10 @@ class Sender {
 }
 
 class Message {
-	String subject;
-	String body;
-	String htmlBody;
+	LocalizedString subject;
+	LocalizedString body;
+	LocalizedString htmlBody;
+	Locale extraBccsLocale;
 	DateTime created;
     protected ReplyTos replyToArray (REQUIRED);
 	String extraBccs;

--- a/core/src/main/java/org/fenixedu/messaging/domain/Message.java
+++ b/core/src/main/java/org/fenixedu/messaging/domain/Message.java
@@ -26,14 +26,21 @@ package org.fenixedu.messaging.domain;
 
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.fenixedu.bennu.core.domain.User;
+import org.fenixedu.bennu.core.domain.UserProfile;
 import org.fenixedu.bennu.core.domain.groups.PersistentGroup;
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.security.Authenticate;
+import org.fenixedu.commons.i18n.I18N;
+import org.fenixedu.commons.i18n.LocalizedString;
 import org.joda.time.DateTime;
 
 import pt.ist.fenixframework.Atomic;
@@ -52,31 +59,66 @@ public final class Message extends Message_Base implements Comparable<Message> {
         private static final long serialVersionUID = 525424959825814582L;
 
         private Sender sender;
-
-        private String subject;
-
-        private String body;
-
-        private String htmlBody;
-
-        private Set<Group> to = new HashSet<>();
-
-        private Set<Group> cc = new HashSet<>();
-
-        private Set<Group> bcc = new HashSet<>();
-
+        private LocalizedString subject, body, htmlBody;
+        private Locale extraBccsLocale = I18N.getLocale();
+        private Set<Group> to = new HashSet<>(), cc = new HashSet<>(), bcc = new HashSet<>();
         private Set<String> extraBcc = new HashSet<>();
-
         private Set<ReplyTo> replyTo = new HashSet<>();
 
-        public MessageBuilder(Sender sender, String subject, String body) {
+        public MessageBuilder(Sender sender, LocalizedString subject, LocalizedString body) {
             this.sender = sender;
             this.subject = subject;
             this.body = body;
         }
 
-        public MessageBuilder htmlBody(String htmlBody) {
+        public MessageBuilder(Sender sender, String subject, String body, Locale locale) {
+            this.sender = sender;
+            this.subject = new LocalizedString(locale, subject);
+            this.body = new LocalizedString(locale, body);
+        }
+
+        public MessageBuilder subject(LocalizedString subject) {
+            this.subject = subject;
+            return this;
+        }
+
+        public MessageBuilder subjectLocale(Locale locale, String subject) {
+            this.subject = this.subject.with(locale, subject);
+            return this;
+        }
+
+        public MessageBuilder body(LocalizedString body) {
+            this.body = body;
+            return this;
+        }
+
+        public MessageBuilder bccLocale(Locale extraBccsLocale) {
+            this.extraBccsLocale = extraBccsLocale;
+            return this;
+        }
+
+        public MessageBuilder bodyLocale(Locale locale, String body) {
+            this.body = this.body.with(locale, body);
+            return this;
+        }
+
+        public MessageBuilder contentLocale(Locale locale, String subject, String body) {
+            this.subject = this.subject.with(locale, subject);
+            this.body = this.body.with(locale, body);
+            return this;
+        }
+
+        public MessageBuilder htmlBody(LocalizedString htmlBody) {
             this.htmlBody = htmlBody;
+            return this;
+        }
+
+        public MessageBuilder htmlBodyLocale(Locale locale, String htmlBody) {
+            if (this.htmlBody != null) {
+                this.htmlBody = this.htmlBody.with(locale, htmlBody);
+            } else {
+                this.htmlBody = new LocalizedString(locale, htmlBody);
+            }
             return this;
         }
 
@@ -140,7 +182,7 @@ public final class Message extends Message_Base implements Comparable<Message> {
         }
 
         public Message send() {
-            return new Message(sender, subject, body, htmlBody, to, cc, bcc, extraBcc, replyTo);
+            return new Message(sender, subject, body, htmlBody, to, cc, bcc, extraBcc, replyTo, extraBccsLocale);
         }
     }
 
@@ -165,10 +207,11 @@ public final class Message extends Message_Base implements Comparable<Message> {
         setMessagingSystemFromPendingDispatch(messagingSystem);
         setCreated(new DateTime());
         setUser(Authenticate.getUser());
+        setExtraBccsLocale(I18N.getLocale());
     }
 
-    Message(Sender sender, String subject, String body, String htmlBody, Set<Group> to, Set<Group> cc, Set<Group> bcc,
-            Set<String> extraBccs, Set<ReplyTo> replyTos) {
+    Message(Sender sender, LocalizedString subject, LocalizedString body, LocalizedString htmlBody, Set<Group> to, Set<Group> cc,
+            Set<Group> bcc, Set<String> extraBccs, Set<ReplyTo> replyTos) {
         this();
         setSender(sender);
         if (to != null) {
@@ -193,6 +236,23 @@ public final class Message extends Message_Base implements Comparable<Message> {
         setSubject(subject);
         setBody(body);
         setHtmlBody(htmlBody);
+    }
+
+    Message(Sender sender, LocalizedString subject, LocalizedString body, LocalizedString htmlBody, Set<Group> to, Set<Group> cc,
+            Set<Group> bcc, Set<String> extraBccs, Set<ReplyTo> replyTos, Locale extraBccsLocale) {
+        this(sender, subject, body, htmlBody, to, cc, bcc, extraBccs, replyTos);
+        setExtraBccsLocale(extraBccsLocale);
+    }
+
+    Message(Sender sender, String subject, String body, String htmlBody, Set<Group> to, Set<Group> cc, Set<Group> bcc,
+            Set<String> extraBccs, Set<ReplyTo> replyTos, Locale locale) {
+        this(sender, new LocalizedString(locale, subject), new LocalizedString(locale, body), new LocalizedString(locale,
+                htmlBody), to, cc, bcc, extraBccs, replyTos);
+    }
+
+    Message(Sender sender, String subject, String body, String htmlBody, Set<Group> to, Set<Group> cc, Set<Group> bcc,
+            Set<String> extraBccs, Set<ReplyTo> replyTos) {
+        this(sender, subject, body, htmlBody, to, cc, bcc, extraBccs, replyTos, I18N.getLocale());
     }
 
     @Override
@@ -254,12 +314,63 @@ public final class Message extends Message_Base implements Comparable<Message> {
 
     public Set<String> getBccs() {
         Set<String> base = recipientsToEmails(getBccSet());
-        if (getExtraBccs() != null && !getExtraBccs().isEmpty()) {
-            Set<String> extended = Sets.newHashSet(getExtraBccs().replace(',', ' ').replace(';', ' ').split("\\s+"));
-            extended.addAll(base);
-            return extended;
-        }
+        base.addAll(getExtraBccsSet());
         return base;
+    }
+
+    public Set<String> getExtraBccsSet() {
+        String extraBccs = getExtraBccs();
+        if (!Strings.isNullOrEmpty(extraBccs)) {
+            return Sets.newHashSet(getExtraBccs().replace(',', ' ').replace(';', ' ').split("\\s+"));
+        } else {
+            return Sets.newHashSet();
+        }
+    }
+
+    private static Map<Locale, Set<String>> emailsByLocale(Set<PersistentGroup> groups, Predicate<String> emailValidator) {
+        Map<Locale, Set<String>> emails = new HashMap<Locale, Set<String>>();
+        Locale defLocale = Locale.getDefault();
+        for (PersistentGroup group : groups) {
+            for (User u : group.getMembers()) {
+                UserProfile profile = u.getProfile();
+                Locale l = profile.getPreferredLocale();
+                if (l == null) {
+                    l = defLocale;
+                }
+                String email = profile.getEmail();
+                if (emailValidator.test(email)) {
+                    emails.computeIfAbsent(l, k -> new HashSet<>()).add(email);
+                }
+            }
+        }
+        return emails;
+    }
+
+    public Map<Locale, Set<String>> getTosByLocale() {
+        return getTosByLocale(e -> true);
+    }
+
+    public Map<Locale, Set<String>> getTosByLocale(Predicate<String> emailValidator) {
+        return emailsByLocale(getToSet(), emailValidator);
+    }
+
+    public Map<Locale, Set<String>> getCcsByLocale() {
+        return getCcsByLocale(e -> true);
+    }
+
+    public Map<Locale, Set<String>> getCcsByLocale(Predicate<String> emailValidator) {
+        return emailsByLocale(getCcSet(), emailValidator);
+    }
+
+    public Map<Locale, Set<String>> getBccsByLocale() {
+        return getCcsByLocale(e -> true);
+    }
+
+    public Map<Locale, Set<String>> getBccsByLocale(Predicate<String> emailValidator) {
+        Map<Locale, Set<String>> bccs = emailsByLocale(getBccSet(), emailValidator);
+        Locale extraBccsLocale = getExtraBccsLocale();
+        bccs.computeIfAbsent(extraBccsLocale, k -> new HashSet<>()).addAll(getExtraBccsSet());
+        return bccs;
     }
 
     public Set<String> getReplyTos() {

--- a/core/src/main/java/org/fenixedu/messaging/domain/Sender.java
+++ b/core/src/main/java/org/fenixedu/messaging/domain/Sender.java
@@ -35,7 +35,6 @@ import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.domain.groups.PersistentGroup;
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.security.Authenticate;
-import org.fenixedu.messaging.domain.Message.MessageBuilder;
 
 /**
  *
@@ -140,10 +139,6 @@ public class Sender extends Sender_Base {
 
     public void pruneOldMessages() {
         getPolicy().pruneSender(this);
-    }
-
-    public MessageBuilder message(String subject, String body) {
-        return new MessageBuilder(this, subject, body);
     }
 
     public static boolean userHasRecipients() {

--- a/core/src/main/resources/MessagingResources_en.properties
+++ b/core/src/main/resources/MessagingResources_en.properties
@@ -19,7 +19,7 @@ label.bootstrapper.systemsender.address = Address
 label.bootstrapper.systemsender.group = Sender Group
 label.bootstrapper.systemsender.name = Name
 
-message.footer = {0}\n\n---\nThis message was sent by {1}, to the following recipients:\n\t{2}\n
+message.footer = \n\n---\nThis message was sent by {0}, to the following recipients:\n\t{1}
 
 name.deletion.policy.messages = up to {0} messages
 name.deletion.policy.period = for {0}

--- a/core/src/main/resources/MessagingResources_pt.properties
+++ b/core/src/main/resources/MessagingResources_pt.properties
@@ -19,7 +19,7 @@ label.bootstrapper.systemsender.address = Endereço
 label.bootstrapper.systemsender.group = Grupo de Envio
 label.bootstrapper.systemsender.name = Nome
 
-message.footer = {0}\n\n---\nEsta mensagem foi enviada em nome do(a) {1}, para os seguintes destinatários:\n\t{2}\n
+message.footer = \n\n---\nEsta mensagem foi enviada em nome do(a) {0}, para os seguintes destinatários:\n\t{1}
 
 name.deletion.policy.messages = até {0} mensagens
 name.deletion.policy.period = for {0}

--- a/core/src/main/webapp/WEB-INF/messaging/listSenders.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/listSenders.jsp
@@ -19,14 +19,14 @@
 		<tbody>
 		<c:forEach items="${senders}" var="sender">
 			<tr onClick="location.href='${pageContext.request.contextPath}/messaging/sender/${sender.externalId}'">
-				<td class="col-xs-5">
+				<td class="col-sm-5">
 					${sender.fromName}
 				</td>
-				<td class="col-xs-4">
-					<span class="label label-default">${sender.fromAddress}</span>
+				<td class="col-sm-4">
+					<code>${sender.fromAddress}</code>
 				</td>
-				<td class="col-xs-3">
-					<div class="btn-group pull-right">
+				<td class="col-sm-3">
+					<div class="btn-group btn-group-xs pull-right">
 						<a class="btn btn-primary" href="${pageContext.request.contextPath}/messaging/message?sender=${sender.externalId}">
 							<spring:message code="action.message.new"/>
 						</a>

--- a/core/src/main/webapp/WEB-INF/messaging/newMessage.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/newMessage.jsp
@@ -3,6 +3,8 @@
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring"%>
 <%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
 
+${portal.toolkit()}
+
 <h2><spring:message code="title.message.new"/></h2>
 
 <c:if test="${not empty messageBean.errors}">
@@ -30,7 +32,7 @@
 	</div>
 	<div class="form-group">
 		<label class="control-label col-sm-2"><spring:message code="label.message.replyTos"/>:</label>
-		<div id="replyTos" class="col-sm-10">
+		<div id="replyTos" class="form-inline col-sm-10">
 			<c:forEach  var="replyTo" items="${messageBean.replyTos}">
 				<input style="display:none;" type="checkbox" value="${replyTo}" checked/>
 			</c:forEach>
@@ -38,7 +40,7 @@
 	</div>
 	<div class="form-group">
 		<label class="control-label col-sm-2"><spring:message code="label.message.bccs"/>:</label>
-		<div id="recipients" class="col-sm-10">
+		<div id="recipients" class="form-inline col-sm-10">
 			<c:forEach  var="recipient" items="${messageBean.recipients}">
 				<input style="display:none;" type="checkbox" value="${recipient}" checked/>
 			</c:forEach>
@@ -48,25 +50,35 @@
 		<label class="control-label col-sm-2" for="bccs"><spring:message code="label.message.bccs.extra"/>:</label>
 		<div class="col-sm-10">
 			<spring:message code="hint.extra.bccs" var="placeholder"/>
-			<form:input class="form-control" id="bccs" size="50" path="bccs" placeholder="${placeholder}" pattern="^\s*[^@,\s]+@[^@,\s]+(\s*,\s*[^@,\s]+@[^@,\s]+)*$"/>
+			<form:input type="email" multiple="multiple" class="form-control" id="bccs" path="bccs" placeholder="${placeholder}"/>
+		</div>
+	</div>
+	<div class="form-group">
+		<label class="control-label col-sm-2" for=extraBccsLocale><spring:message code="label.message.bccs.extra.locale"/>:</label>
+		<div class="col-sm-10">
+			<form:select class="form-control" id="extraBccsLocale" path="extraBccsLocale">
+				<c:forEach items="${supportedLocales}" var="locale">
+					<form:option value="locale">${locale.getDisplayName(locale)}</form:option>
+				</c:forEach>
+			</form:select>
 		</div>
 	</div>
 	<div class="form-group">
 		<label class="control-label col-sm-2" for="subject"><spring:message code="label.message.subject"/>:</label>
 		<div class="col-sm-10">
-			<form:input class="form-control" id="subject" size="50" path="subject" required="true"/>
+			<input class="form-control" id="subject" name="subject" value='<c:out value="${messageBean.subject.json()}"/>' bennu-localized-string required-any/>
 		</div>
 	</div>
 	<div class="form-group">
-		<label class="control-label col-sm-2" for="message"><spring:message code="label.message.body"/>:</label>
+		<label class="control-label col-sm-2" for="body"><spring:message code="label.message.body"/>:</label>
 		<div class="col-sm-10">
-			<form:textarea class="form-control" id="message" cols="80" rows="10" path="message"/>
+			<textarea class="form-control" id="body" name="body" bennu-localized-string>${messageBean.body.json()}</textarea>
 		</div>
 	</div>
 	<div id="htmlMessage" class="form-group">
-		<label class="control-label col-sm-2" for="message"><spring:message code="label.message.body.html"/>:</label>
+		<label class="control-label col-sm-2" for="htmlBody"><spring:message code="label.message.body.html"/>:</label>
 		<div class="col-sm-10">
-			<form:textarea class="form-control" id="message" cols="80" rows="10" path="htmlMessage"/>
+			<textarea class="form-control" id="htmlBody" name="htmlBody" bennu-html-editor bennu-localized-string/>${messageBean.htmlBody.json()}</textarea>
 		</div>
 	</div>
 	<div class="form-group">
@@ -74,62 +86,68 @@
 			<button class="btn btn-primary" type="submit"><spring:message code="action.message.send"/></button>
 		</div>
 	</div>
-	<script>
-		function recallCheckboxes(container){
-			var checked = [];
-			container.children("input:checked").each(function() {
-				checked.push($(this).val());
-		    });
-			container.empty();
-			return checked;
-		}
-
-		function caseInsensitiveCompare(property, a, b) {
-			a = property ? a[property] : a;
-			b = property ? b[property] : b;
-			a = a.toUpperCase();
-			b = b.toUpperCase();
-			if(a < b) return -1;
-			if(a > b) return 1;
-			return 0;
-		}
-
-		function appendCheckbox(element, checked, name, label, id){
-			$('<input/>', { type: 'checkbox', id: id, value: id, name: name, checked: checked.indexOf(id) >= 0 }).appendTo(element);
-			element.append("&nbsp;");
-			$('<label class="label label-default" for="'+id+'">&nbsp;'+label+'</label>').appendTo(element);
-			$('<br/>').appendTo(element);
-		}
-
-		function populateCheckboxes(info, path, element, sortProperty, labelProperty, idProperty) {
-			element.parent().hide();
-			var checked = recallCheckboxes(element),
-				data = info[path];
-			if(data.length !== 0) {
-				element.parent().show();
-				data.sort(caseInsensitiveCompare.bind(undefined, sortProperty)).forEach(function(item){
-					appendCheckbox(element, checked, path, labelProperty ? item[labelProperty] : item, idProperty ? item[idProperty] : item);
-				});
-			}
-		}
-
-		function senderUpdate(sender){
-			if(sender){
-				$.getJSON('sender/' + sender, function(info){
-					populateCheckboxes(info, 'replyTos', $('#replyTos'), null, null, null);
-					populateCheckboxes(info, 'recipients', $('#recipients'), 'name', 'name', 'expression');
-					if(info.html){
-						$('#htmlMessage').show();
-					} else {
-						$('#htmlMessage').hide();
-					}
-				});
-			}
-		}
-
-		$('#senderSelect').change(function(){
-			senderUpdate(this.value);
-		});
-		senderUpdate(<c:out value="${messageBean.sender.externalId}"/>);
-	</script>
 </form:form>
+<script>
+(function(){
+	function recallCheckboxes(container){
+		var checked = [];
+		container.children("input:checked").each(function() {
+			checked.push($(this).val());
+		});
+		container.empty();
+		return checked;
+	}
+
+	function caseInsensitiveCompare(property, a, b) {
+		a = property ? a[property] : a;
+		b = property ? b[property] : b;
+		a = a.toUpperCase();
+		b = b.toUpperCase();
+		if(a < b) return -1;
+		if(a > b) return 1;
+		return 0;
+	}
+
+	function appendCheckbox(element, checked, name, label, id){
+		var labelEl = $('<label style="margin-right: 5px;" class="input-group input-group-sm" for="'+id+'"></label>');
+		var checkboxEl = $('<input/>', { type: 'checkbox', id: id, value: id, name: name, checked: checked.indexOf(id) >= 0 });
+		var addonEl = $('<span class="input-group-addon"></span>');
+		var spanEl = $('<span class="form-control">'+label+'</span>');
+		addonEl.append(checkboxEl);
+		labelEl.append(addonEl);
+		labelEl.append(spanEl);
+		element.append(labelEl);
+	}
+
+	function populateCheckboxes(info, path, element, sortProperty, labelProperty, idProperty) {
+		element.parent().hide();
+		var checked = recallCheckboxes(element),
+			data = info[path];
+		if(data.length !== 0) {
+			element.parent().show();
+			data.sort(caseInsensitiveCompare.bind(undefined, sortProperty)).forEach(function(item){
+				appendCheckbox(element, checked, path, labelProperty ? item[labelProperty] : item, idProperty ? item[idProperty] : item);
+			});
+		}
+	}
+
+	function senderUpdate(sender){
+		if(sender){
+			$.getJSON('sender/' + sender, function(info){
+				populateCheckboxes(info, 'replyTos', $('#replyTos'), null, null, null);
+				populateCheckboxes(info, 'recipients', $('#recipients'), 'name', 'name', 'expression');
+				if(info.html){
+					$('#htmlMessage').show();
+				} else {
+					$('#htmlMessage').hide();
+				}
+			});
+		}
+	}
+
+	$('#senderSelect').change(function(){
+		senderUpdate(this.value);
+	});
+	senderUpdate(<c:out value="${messageBean.sender.externalId}"/>);
+})();
+</script>

--- a/core/src/main/webapp/WEB-INF/messaging/viewMessage.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/viewMessage.jsp
@@ -1,7 +1,10 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
 <%@ taglib uri="http://www.springframework.org/tags" prefix="spring"%>
+
+${portal.toolkit()}
 
 <h2><spring:message code="title.message"/></h2>
 
@@ -80,7 +83,7 @@
 				<spring:message code="label.message.sender.address"/>
 			</th>
 			<td>
-				<span class="label label-default">${message.sender.fromAddress}</span>
+				<code>${message.sender.fromAddress}</code>
 			</td>
 		</tr>
 		<tr>
@@ -88,7 +91,7 @@
 				<spring:message code="label.message.sent.by"/>
 			</th>
 			<td>
-				${message.user.presentationName}
+				${message.user.profile.displayName}
 			</td>
 		</tr>
 		<c:if test="${not empty message.replyTos}">
@@ -98,7 +101,7 @@
 				</th>
 				<td>
 					<c:forEach items="${message.replyTos}" var="replyTo">
-						<span class="label label-default">${replyTo}</span>
+						<code>${replyTo}</code>
 					</c:forEach>
 				</td>
 			</tr>
@@ -108,9 +111,9 @@
 				<th class="col-md-2" scope="row">
 					<spring:message code="label.message.tos"/>
 				</th>
-				<td>
+				<td class="form-inline">
 					<c:forEach items="${message.toGroup}" var="to">
-						<span class="label label-default">${to.presentationName}</span>
+						<label class="form-control input-sm">${to.presentationName}</label>
 					</c:forEach>
 				</td>
 			</tr>
@@ -120,9 +123,9 @@
 				<th class="col-md-2" scope="row">
 					<spring:message code="label.message.ccs"/>
 				</th>
-				<td>
+				<td class="form-inline">
 					<c:forEach items="${message.ccGroup}" var="cc">
-						<span class="label label-default">${cc.presentationName}</span>
+						<label class="form-control input-sm">${cc.presentationName}</label>
 					</c:forEach>
 				</td>
 			</tr>
@@ -132,9 +135,9 @@
 				<th class="col-md-2" scope="row">
 					<spring:message code="label.message.bccs"/>
 				</th>
-				<td>
+				<td class="form-inline">
 					<c:forEach items="${message.bccGroup}" var="bcc">
-						<span class="label label-default">${bcc.presentationName}</span>
+						<label class="form-control input-sm">${bcc.presentationName}</label>
 					</c:forEach>
 				</td>
 			</tr>
@@ -146,17 +149,41 @@
 				</th>
 				<td>
 					<c:forEach items="${message.extraBccs}" var="bcc">
-						<span class="label label-default">${bcc}</span>
+						<code>${bcc}</code>
 					</c:forEach>
+				</td>
+			</tr>
+			<tr>
+				<th class="col-md-2" scope="row">
+					<spring:message code="label.message.bccs.extra.locale"/>
+				</th>
+				<td>
+					${message.extraBccsLocale.getDisplayName(message.extraBccsLocale)}
 				</td>
 			</tr>
 		</c:if>
 		<tr>
 			<th class="col-md-2" scope="row">
+				<spring:message code="label.message.locale"/>
+			</th>
+			<td>
+				<ul class="nav nav-pills">
+				<c:forEach items="${messageLocales}" var="locale">
+					<li><a class="btn-sm localized" id="locale-${locale}">${locale.getDisplayName(locale)}</a></li>
+				</c:forEach>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th class="col-md-2" scope="row">
 				<spring:message code="label.message.subject"/>
 			</th>
 			<td>
-				<c:out value="${message.subject}"/>
+			<c:forEach items="${messageLocales}" var="locale">
+				<div class="panel panel-default localized locale-${locale}" style="margin:0;">
+					<div style="white-space: pre-wrap;" class="panel-heading"><c:out value="${message.subject.getContent(locale)}" default="${message.subject.getContent()}"/></div>
+				</div>
+			</c:forEach>
 			</td>
 		</tr>
 		<c:if test="${not empty message.body}">
@@ -165,9 +192,11 @@
 				<spring:message code="label.message.body"/>
 			</th>
 			<td>
-				<div class="panel panel-default">
-					<div style="white-space: pre-wrap;" class="panel-body"><c:out value="${message.body}"/></div>
+			<c:forEach items="${messageLocales}" var="locale">
+				<div class="panel panel-default localized locale-${locale}" style="margin:0;">
+					<div style="white-space: pre-wrap;" class="panel-heading"><c:out value="${message.body.getContent(locale)}" default="${message.body.getContent()}"/></div>
 				</div>
+			</c:forEach>
 			</td>
 		</tr>
 		</c:if>
@@ -177,9 +206,11 @@
 				<spring:message code="label.message.body.html"/>
 			</th>
 			<td>
-				<div class="panel panel-default">
-					<div style="white-space: pre-wrap;" class="panel-body"><c:out value="${message.htmlBody}"/></div>
+			<c:forEach items="${messageLocales}" var="locale">
+				<div class="panel panel-default localized locale-${locale}" style="margin:0;">
+					<div style="white-space: pre-wrap;" class="panel-heading"><c:out value="${message.htmlBody.getContent(locale)}" default="${message.htmlBody.getContent()}" escapeXml="false"/></div>
 				</div>
+			</c:forEach>
 			</td>
 		</tr>
 		</c:if>
@@ -195,3 +226,20 @@
 		</c:if>
 	</tbody>
 </table>
+<script>
+(function() {
+	var pills=$("a.localized");
+	var content=$("div.localized");
+	function selectLocale(locale){
+		pills.parent().removeClass("active");
+		$("#"+locale).parent().addClass("active");
+		content.hide();
+		$("div."+locale).show();
+	}
+	pills.click(function(event){
+		selectLocale($(event.target).attr('id'));
+	})
+	var firstLocale="<c:forEach items="${messageLocales}" var="locale" end="0">locale-<c:out value="${locale}"/></c:forEach>";
+	selectLocale(firstLocale);
+})();
+</script>

--- a/core/src/main/webapp/WEB-INF/messaging/viewSender.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/viewSender.jsp
@@ -19,7 +19,7 @@
 				<spring:message code="label.bootstrapper.systemsender.address"/>
 			</th>
 			<td>
-				<span class="label label-default">${sender.fromAddress}</span>
+				<code>${sender.fromAddress}</code>
 			</td>
 		</tr>
 		<c:if test="${not empty sender.replyTos}">
@@ -29,7 +29,7 @@
 				</th>
 				<td>
 					<c:forEach items="${sender.replyTos}" var="replyTo">
-						<span class="label label-default">${replyTo.address}</span>
+						<code>${replyTo.address}</code>
 					</c:forEach>
 				</td>
 			</tr>
@@ -70,9 +70,9 @@
 		<tbody>
 		<c:forEach items="${messages}" var="message">
 			<tr onClick="location.href='${pageContext.request.contextPath}/messaging/message/${message.externalId}'">
-				<td class="col-xs-2">${message.created.toString("dd-MM-yyyy HH:mm:ss")}</td>
-				<td class="col-xs-6">${message.subject}</td>
-				<td class="col-xs-3">
+				<td class="col-sm-2">${message.created.toString("dd-MM-yyyy HH:mm:ss")}</td>
+				<td class="col-sm-6"><c:out value="${message.subject.content}"/></td>
+				<td class="col-sm-3">
 					<c:choose>
 						<c:when test="${not empty message.sent}">
 							${message.sent.toString("dd-MM-yyyy HH:mm:ss")}
@@ -106,8 +106,8 @@
 						</c:otherwise>
 					</c:choose>
 				</td>
-				<td class="col-xs-1">
-					<a class="btn btn-default pull-right" href="${pageContext.request.contextPath}/messaging/message/${message.externalId}">
+				<td class="col-sm-1">
+					<a class="btn btn-xs btn-default pull-right" href="${pageContext.request.contextPath}/messaging/message/${message.externalId}">
 						<spring:message code="action.view.details"/>
 					</a>
 				</td>

--- a/core/src/main/webapp/WEB-INF/resources/MessagingResources_en.properties
+++ b/core/src/main/webapp/WEB-INF/resources/MessagingResources_en.properties
@@ -10,10 +10,12 @@ hint.extra.bccs = someone@example.com, ...
 
 label.message.bccs = Recipients (Bcc)
 label.message.bccs.extra = Other Recipients (Bcc)
+label.message.bccs.extra.locale = Other Recipients Locale
 label.message.body = Message
 label.message.body.html = HTML Message
 label.message.ccs = Recipients (Cc)
 label.message.created = Created
+label.message.locale = Content Locales
 label.message.replyTos = Reply to
 label.message.sender = Sender
 label.message.sender.name = Sender Name

--- a/core/src/main/webapp/WEB-INF/resources/MessagingResources_pt.properties
+++ b/core/src/main/webapp/WEB-INF/resources/MessagingResources_pt.properties
@@ -10,10 +10,12 @@ hint.extra.bccs = alguem@exemplo.pt, ...
 
 label.message.bccs = Destinatários (Bcc)
 label.message.bccs.extra = Outros Destinatários (Bcc)
+label.message.bccs.extra.locale = Localização para Outros Destinatários
 label.message.body = Mensagem
 label.message.body.html = Mensagem HTML
 label.message.ccs = Destinatários (Cc)
 label.message.created = Criado
+label.message.locale = Localizações do Conteúdo
 label.message.replyTos = Responder a
 label.message.sender = Remetente
 label.message.sender.name = Nome do Remetente

--- a/email-dispatch/src/main/dml/email-dispatch.dml
+++ b/email-dispatch/src/main/dml/email-dispatch.dml
@@ -6,6 +6,7 @@ class MimeMessageHandler {
     protected String toAddresses;
     protected String ccAddresses;
     protected String bccAddresses;
+    protected Locale locale;
 }
 
 class EmailBlacklist {


### PR DESCRIPTION
Message subject, body and html body are now LocalizedStrings. The email
dispatcher builds individual emails using the user's preferred locale
or, in the case of email only bccs, a sender specified locale. When a
content type is not defined for the user's locale the regular fallback
strategies are used. Interfaces display the resulting email content for
all supported locales plus any other locale for which the message has
specific content (usually set programmatically).
Additionally common message sending behaviour was grouped into the
MessageBean class and several styling adjustments were made to the
interface.