### PR TITLE
Add message templates for sending institutional messages programmatically

### DIFF
--- a/core/src/main/dml/messaging.dml
+++ b/core/src/main/dml/messaging.dml
@@ -1,24 +1,24 @@
 package org.fenixedu.messaging.domain;
 
 valueType org.fenixedu.messaging.domain.MessageDeletionPolicy as MessageDeletionPolicy {
-    externalizeWith {
-        String serialize();
-    }
-    internalizeWith internalize();
+	externalizeWith {
+		String serialize();
+	}
+	internalizeWith internalize();
 }
 
 valueType org.fenixedu.messaging.domain.ReplyTos as ReplyTos {
-    externalizeWith {
-        String serialize();
-    }
-    internalizeWith internalize();
+	externalizeWith {
+		String serialize();
+	}
+	internalizeWith internalize();
 }
 
 class MessagingSystem {
 }
 
 class Sender {
-    boolean htmlSender;
+	boolean htmlSender;
 	String fromName;
 	String fromAddress;
 	protected ReplyTos replyToArray (REQUIRED);
@@ -31,25 +31,40 @@ class Message {
 	LocalizedString htmlBody;
 	Locale extraBccsLocale;
 	DateTime created;
-    protected ReplyTos replyToArray (REQUIRED);
+	protected ReplyTos replyToArray (REQUIRED);
 	String extraBccs;
 }
 
+class MessageTemplate {
+	String id;
+	LocalizedString textBody;
+	LocalizedString htmlBody;
+}
+
 class MessageDispatchReport {
-    public DateTime startedDelivery;
-    public DateTime finishedDelivery;
-    public int totalCount;
-    public int deliveredCount;
-    public int invalidCount;
-    public int failedCount;
+	public DateTime startedDelivery;
+	public DateTime finishedDelivery;
+	public int totalCount;
+	public int deliveredCount;
+	public int invalidCount;
+	public int failedCount;
 }
 
 relation MessagingSystemRoot {
-    protected .org.fenixedu.bennu.core.domain.Bennu playsRole bennu {
-        multiplicity 1..1;
-    }
+	protected .org.fenixedu.bennu.core.domain.Bennu playsRole bennu {
+		multiplicity 1..1;
+	}
 	public MessagingSystem playsRole messagingSystem {
-        multiplicity 0..1;
+		multiplicity 0..1;
+	}
+}
+
+relation MessagingSystemTemplate {
+	protected MessagingSystem playsRole messagingSystem {
+		multiplicity 1..1;
+	}
+	protected MessageTemplate playsRole template {
+		multiplicity *;
 	}
 }
 
@@ -63,12 +78,12 @@ relation MessagingSystemSender {
 }
 
 relation MessagingSystemSystemSender {
-    protected MessagingSystem playsRole rootForSystemSender {
-        multiplicity 0..1;
-    }
-    public Sender playsRole systemSender {
-        multiplicity 0..1;
-    }
+	protected MessagingSystem playsRole rootForSystemSender {
+		multiplicity 0..1;
+	}
+	public Sender playsRole systemSender {
+		multiplicity 0..1;
+	}
 }
 
 relation MessagingSystemMessage {
@@ -82,20 +97,20 @@ relation MessagingSystemMessage {
 
 relation MessagingSystemMessagePending {
 	protected MessagingSystem playsRole messagingSystemFromPendingDispatch {
-        multiplicity 0..1;
-    }
+		multiplicity 0..1;
+	}
 	protected Message playsRole messagePendingDispatch {
 		multiplicity *;
 	}
 }
 
 relation MessageDispatchReports {
-    protected Message playsRole message {
-        multiplicity 1..1;
-    }
-    protected MessageDispatchReport playsRole dispatchReport {
-        multiplicity 0..1;
-    }
+	protected Message playsRole message {
+		multiplicity 1..1;
+	}
+	protected MessageDispatchReport playsRole dispatchReport {
+		multiplicity 0..1;
+	}
 }
 
 relation SenderPersistentGroupMembers {

--- a/core/src/main/java/org/fenixedu/messaging/domain/MessageTemplate.java
+++ b/core/src/main/java/org/fenixedu/messaging/domain/MessageTemplate.java
@@ -1,0 +1,61 @@
+package org.fenixedu.messaging.domain;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.fenixedu.commons.i18n.LocalizedString;
+import org.fenixedu.messaging.exception.MessagingDomainException;
+
+import com.mitchellbosecke.pebble.PebbleEngine;
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.loader.StringLoader;
+
+public class MessageTemplate extends MessageTemplate_Base {
+    private static final PebbleEngine engine = new PebbleEngine(new StringLoader());
+
+    protected MessageTemplate() {
+        super();
+        setMessagingSystem(MessagingSystem.getInstance());
+    }
+
+    public LocalizedString getCompiledTextBody(Map<String, Object> context) {
+        return compile(getTextBody(), context);
+    }
+
+    public LocalizedString getCompiledHtmlBody(Map<String, Object> context) {
+        return compile(getHtmlBody(), context);
+    }
+
+    private LocalizedString compile(LocalizedString template, Map<String, Object> context) {
+        List<String> localizable =
+                context.keySet().stream().filter(k -> context.get(k) instanceof LocalizedString).collect(Collectors.toList());
+        Map<String, Object> localized = new HashMap<>(context);
+
+        LocalizedString result = new LocalizedString();
+        for (Locale locale : template.getLocales()) {
+            localizable.forEach(k -> {
+                LocalizedString toLocalize = (LocalizedString) context.get(k);
+                String content = toLocalize.getContent(locale);
+                localized.put(k, content != null ? content : toLocalize.getContent());
+            });
+            try (StringWriter writer = new StringWriter()) {
+                engine.getTemplate(template.getContent(locale)).evaluate(writer, localized, locale);
+                result = result.with(locale, writer.toString());
+            } catch (PebbleException | IOException e) {
+                throw MessagingDomainException.malformedTemplate(e, getId());
+            }
+        }
+        return result;
+    }
+
+    public void delete() {
+        setMessagingSystem(null);
+        deleteDomainObject();
+    }
+
+}

--- a/core/src/main/java/org/fenixedu/messaging/domain/ReplyTos.java
+++ b/core/src/main/java/org/fenixedu/messaging/domain/ReplyTos.java
@@ -1,6 +1,7 @@
 package org.fenixedu.messaging.domain;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -15,15 +16,23 @@ public class ReplyTos implements Serializable {
     private final ImmutableSet<ReplyTo> replyTos;
 
     public ReplyTos(ImmutableSet<ReplyTo> replyTos) {
-        this.replyTos = replyTos;
+        if (replyTos == null) {
+            this.replyTos = ImmutableSet.of();
+        } else {
+            this.replyTos = replyTos;
+        }
     }
 
     public ReplyTos(Set<ReplyTo> replyTos) {
-        this.replyTos = ImmutableSet.copyOf(replyTos);
+        if (replyTos == null) {
+            this.replyTos = ImmutableSet.of();
+        } else {
+            this.replyTos = ImmutableSet.copyOf(replyTos);
+        }
     }
 
     public ReplyTos(String... replyTos) {
-        this.replyTos = ImmutableSet.of();
+        this.replyTos = ImmutableSet.copyOf(Arrays.stream(replyTos).map(rt -> ReplyTo.parse(rt)).collect(Collectors.toSet()));
     }
 
     public ReplyTos add(ReplyTo replyTo) {

--- a/core/src/main/java/org/fenixedu/messaging/domain/Sender.java
+++ b/core/src/main/java/org/fenixedu/messaging/domain/Sender.java
@@ -69,7 +69,7 @@ public class Sender extends Sender_Base {
 
     @Override
     public Set<Message> getMessageSet() {
-        // TODO remove when framework supports read-only relations
+        // FIXME remove when framework supports read-only relations
         return Collections.unmodifiableSet(super.getMessageSet());
     }
 

--- a/core/src/main/java/org/fenixedu/messaging/exception/MessagingDomainException.java
+++ b/core/src/main/java/org/fenixedu/messaging/exception/MessagingDomainException.java
@@ -33,11 +33,36 @@ public class MessagingDomainException extends DomainException {
     private static final long serialVersionUID = -8622024813103819898L;
     protected static final String BUNDLE = "MessagingResources";
 
+    protected MessagingDomainException(String bundle, String key, String... args) {
+        super(bundle, key, args);
+    }
+
     protected MessagingDomainException(Response.Status status, String bundle, String key, String... args) {
         super(status, bundle, key, args);
+    }
+
+    protected MessagingDomainException(Throwable cause, String bundle, String key, String... args) {
+        super(cause, bundle, key, args);
+    }
+
+    protected MessagingDomainException(Throwable cause, Response.Status status, String bundle, String key, String... args) {
+        super(cause, status, bundle, key, args);
+    }
+
+    public static MessagingDomainException malformedTemplate(Exception e, String key) {
+        return new MessagingDomainException(e, BUNDLE, "error.template.malformed", key);
+    }
+
+    public static MessagingDomainException nullSender() {
+        return new MessagingDomainException(BUNDLE, "error.message.null.sender");
     }
 
     public static MessagingDomainException forbidden() {
         return new MessagingDomainException(Response.Status.FORBIDDEN, BUNDLE, "error.not.authorized");
     }
+
+    public static MessagingDomainException missingTemplate(String key) {
+        return new MessagingDomainException(Response.Status.NOT_FOUND, BUNDLE, "error.template.missing", key);
+    }
+
 }

--- a/core/src/main/java/org/fenixedu/messaging/template/MessageTemplateDeclaration.java
+++ b/core/src/main/java/org/fenixedu/messaging/template/MessageTemplateDeclaration.java
@@ -1,0 +1,83 @@
+package org.fenixedu.messaging.template;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.fenixedu.bennu.core.i18n.BundleUtil;
+import org.fenixedu.commons.i18n.I18N;
+import org.fenixedu.commons.i18n.LocalizedString;
+import org.fenixedu.messaging.domain.MessageTemplate;
+import org.fenixedu.messaging.template.annotation.DeclareMessageTemplate;
+
+import com.google.common.base.Strings;
+
+public class MessageTemplateDeclaration {
+
+    private MessageTemplate template;
+    private LocalizedString description;
+    private LocalizedString defaultTextBody;
+    private LocalizedString defaultHtmlBody;
+    private Map<String, LocalizedString> parameters;
+
+    public MessageTemplate getTemplate() {
+        return template;
+    }
+
+    public String getId() {
+        return template.getId();
+    }
+
+    public String getExternalId() {
+        return template.getExternalId();
+    }
+
+    public LocalizedString getDescription() {
+        return description;
+    }
+
+    public LocalizedString getDefaultTextBody() {
+        return defaultTextBody;
+    }
+
+    public LocalizedString getTextBody() {
+        return template.getTextBody();
+    }
+
+    public LocalizedString getDefaultHtmlBody() {
+        return defaultHtmlBody;
+    }
+
+    public LocalizedString getHtmlBody() {
+        return template.getHtmlBody();
+    }
+
+    public Map<String, LocalizedString> getParameters() {
+        return parameters;
+    }
+
+    public MessageTemplateDeclaration(MessageTemplate template, DeclareMessageTemplate decl) {
+        if (template == null) {
+            throw new NullPointerException();
+        }
+        this.template = template;
+        String bundle = decl.bundle();
+        this.description = localized(decl.description(), bundle);
+        this.defaultTextBody = localized(decl.text(), bundle);
+        this.defaultHtmlBody = localized(decl.html(), bundle);
+        this.parameters =
+                Arrays.stream(decl.parameters()).collect(
+                        Collectors.toMap(param -> param.id(), param -> localized(param.description(), bundle)));
+    }
+
+    private static LocalizedString localized(String key, String bundle) {
+        LocalizedString localized = null;
+        if (key != null) {
+            localized =
+                    (key.isEmpty() || Strings.isNullOrEmpty(bundle)) ? new LocalizedString(I18N.getLocale(), key) : BundleUtil
+                            .getLocalizedString(bundle, key);
+        }
+        return localized;
+    }
+
+}

--- a/core/src/main/java/org/fenixedu/messaging/template/MessageTemplateDeclarationInitializer.java
+++ b/core/src/main/java/org/fenixedu/messaging/template/MessageTemplateDeclarationInitializer.java
@@ -1,0 +1,32 @@
+package org.fenixedu.messaging.template;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HandlesTypes;
+
+import org.fenixedu.messaging.domain.MessagingSystem;
+import org.fenixedu.messaging.template.annotation.DeclareMessageTemplate;
+import org.fenixedu.messaging.template.annotation.DeclareMessageTemplates;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@HandlesTypes({ DeclareMessageTemplate.class, DeclareMessageTemplates.class })
+public class MessageTemplateDeclarationInitializer implements ServletContainerInitializer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MessageTemplateDeclarationInitializer.class);
+
+    @Override
+    public void onStartup(Set<Class<?>> classes, ServletContext ctx) throws ServletException {
+        LOG.info("Processing messaging templates.");
+        //TODO
+        if (classes != null) {
+            classes.stream().forEach(
+                    c -> Arrays.stream(c.getAnnotationsByType(DeclareMessageTemplate.class)).forEach(
+                            MessagingSystem::declareTemplate));
+        }
+    }
+}

--- a/core/src/main/java/org/fenixedu/messaging/template/annotation/DeclareMessageTemplate.java
+++ b/core/src/main/java/org/fenixedu/messaging/template/annotation/DeclareMessageTemplate.java
@@ -1,0 +1,24 @@
+package org.fenixedu.messaging.template.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(DeclareMessageTemplates.class)
+public @interface DeclareMessageTemplate {
+    String id();
+
+    String description() default "";
+
+    String text() default "";
+
+    String html() default "";
+
+    String bundle() default "";
+
+    TemplateParameter[] parameters() default {};
+}

--- a/core/src/main/java/org/fenixedu/messaging/template/annotation/DeclareMessageTemplates.java
+++ b/core/src/main/java/org/fenixedu/messaging/template/annotation/DeclareMessageTemplates.java
@@ -1,0 +1,12 @@
+package org.fenixedu.messaging.template.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DeclareMessageTemplates {
+    DeclareMessageTemplate[] value();
+}

--- a/core/src/main/java/org/fenixedu/messaging/template/annotation/TemplateParameter.java
+++ b/core/src/main/java/org/fenixedu/messaging/template/annotation/TemplateParameter.java
@@ -1,0 +1,14 @@
+package org.fenixedu.messaging.template.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TemplateParameter {
+    String id();
+
+    String description();
+}

--- a/core/src/main/java/org/fenixedu/messaging/ui/MessageBodyBean.java
+++ b/core/src/main/java/org/fenixedu/messaging/ui/MessageBodyBean.java
@@ -1,0 +1,89 @@
+package org.fenixedu.messaging.ui;
+
+import static pt.ist.fenixframework.FenixFramework.atomic;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.fenixedu.bennu.core.i18n.BundleUtil;
+import org.fenixedu.commons.i18n.LocalizedString;
+import org.fenixedu.messaging.domain.MessageTemplate;
+import org.fenixedu.messaging.template.MessageTemplateDeclaration;
+
+public class MessageBodyBean implements Serializable {
+
+    private static final long serialVersionUID = 7123930613219154850L;
+    protected static final String BUNDLE = "MessagingResources";
+
+    private Set<String> errors;
+    private LocalizedString textBody, htmlBody;
+
+    public MessageBodyBean() {
+    }
+
+    public MessageBodyBean(MessageTemplateDeclaration d) {
+        textBody = d.getDefaultTextBody();
+        htmlBody = d.getDefaultHtmlBody();
+    }
+
+    public MessageBodyBean(MessageTemplate t) {
+        textBody = t.getTextBody();
+        htmlBody = t.getHtmlBody();
+    }
+
+    Set<String> validate() {
+        Set<String> errors = new HashSet<String>();
+        if ((textBody == null || textBody.isEmpty()) && (htmlBody == null || htmlBody.isEmpty())) {
+            errors.add(BundleUtil.getString(BUNDLE, "error.message.validation.message.empty"));
+        }
+        this.errors = errors;
+        return errors;
+    }
+
+    public Set<String> getErrors() {
+        return errors;
+    }
+
+    public LocalizedString getTextBody() {
+        return textBody;
+    }
+
+    public LocalizedString getHtmlBody() {
+        return htmlBody;
+    }
+
+    protected void setErrors(Set<String> errors) {
+        this.errors = errors;
+    }
+
+    public void setTextBody(LocalizedString textBody) {
+        this.textBody = textBody;
+    }
+
+    public void setHtmlBody(LocalizedString htmlBody) {
+        this.htmlBody = htmlBody;
+    }
+
+    public void copy(MessageTemplate template) {
+        if (textBody == null) {
+            textBody = template.getTextBody();
+        }
+        if (htmlBody == null) {
+            htmlBody = template.getHtmlBody();
+        }
+    }
+
+    public boolean edit(MessageTemplate template) {
+        validate();
+        if (errors.isEmpty()) {
+            atomic(() -> {
+                template.setTextBody(textBody);
+                template.setHtmlBody(htmlBody);
+            });
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/core/src/main/java/org/fenixedu/messaging/ui/MessageTemplateDescriptionBean.java
+++ b/core/src/main/java/org/fenixedu/messaging/ui/MessageTemplateDescriptionBean.java
@@ -1,0 +1,54 @@
+package org.fenixedu.messaging.ui;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import org.fenixedu.commons.i18n.LocalizedString;
+import org.fenixedu.messaging.domain.MessageTemplate;
+import org.fenixedu.messaging.template.MessageTemplateDeclaration;
+
+public class MessageTemplateDescriptionBean implements Serializable {
+
+    private static final long serialVersionUID = -1125479922580337020L;
+    public static final Comparator<? super MessageTemplateDescriptionBean> COMPARATOR_BY_ID =
+            new Comparator<MessageTemplateDescriptionBean>() {
+                @Override
+                public int compare(MessageTemplateDescriptionBean b1, MessageTemplateDescriptionBean b2) {
+                    return b1.getId().compareTo(b2.getId());
+                }
+            };
+    private boolean error;
+    private String id, externalId;
+    private LocalizedString description;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public LocalizedString getDescription() {
+        return description;
+    }
+
+    public boolean getError() {
+        return error;
+    }
+
+    public MessageTemplateDescriptionBean(MessageTemplateDeclaration d) {
+        this.id = d.getId();
+        this.description = d.getDescription();
+        MessageTemplate t = d.getTemplate();
+        this.externalId = t.getExternalId();
+        this.error = t.getHtmlBody().isEmpty() && t.getTextBody().isEmpty();
+    }
+
+    public MessageTemplateDescriptionBean(MessageTemplate t) {
+        this.id = t.getId();
+        this.externalId = t.getExternalId();
+        this.error = t.getHtmlBody().isEmpty() && t.getTextBody().isEmpty();
+    }
+
+}

--- a/core/src/main/java/org/fenixedu/messaging/ui/PaginationUtils.java
+++ b/core/src/main/java/org/fenixedu/messaging/ui/PaginationUtils.java
@@ -1,0 +1,48 @@
+package org.fenixedu.messaging.ui;
+
+import java.util.List;
+
+import org.springframework.ui.Model;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+
+public class PaginationUtils {
+
+    private PaginationUtils() {
+    }
+
+    public static <T> List<T> paginate(Model model, String property, List<T> list, int items, int page) {
+        if (list == null || list.isEmpty()) {
+            return null;
+        }
+        items = itemsClip(items, list.size());
+        List<List<T>> pages = Lists.partition(list, items);
+        page = pageClip(page, pages.size());
+        List<T> selected = pages.get(page - 1);
+        if (model != null) {
+            if (!Strings.isNullOrEmpty(property)) {
+                model.addAttribute(property, selected);
+            }
+            model.addAttribute("page", page);
+            model.addAttribute("items", items);
+            model.addAttribute("pages", pages.size());
+        }
+        return selected;
+    }
+
+    private static int itemsClip(int val, int max) {
+        if (val < 1) {
+            return max;
+        }
+        return val;
+    }
+
+    private static int pageClip(int val, int max) {
+        val = val % max;
+        if (val < 1) {
+            return max + val;
+        }
+        return val;
+    }
+}

--- a/core/src/main/java/org/fenixedu/messaging/ui/TemplateConfigController.java
+++ b/core/src/main/java/org/fenixedu/messaging/ui/TemplateConfigController.java
@@ -1,0 +1,85 @@
+package org.fenixedu.messaging.ui;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.fenixedu.bennu.core.util.CoreConfiguration;
+import org.fenixedu.bennu.spring.portal.SpringFunctionality;
+import org.fenixedu.commons.i18n.LocalizedString;
+import org.fenixedu.messaging.domain.MessageTemplate;
+import org.fenixedu.messaging.domain.MessagingSystem;
+import org.fenixedu.messaging.template.MessageTemplateDeclaration;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.google.common.collect.ImmutableMap;
+
+@SpringFunctionality(app = MessagingController.class, title = "title.messaging.templates", accessGroup = "#managers")
+@RequestMapping("/messaging/config/templates")
+public class TemplateConfigController {
+
+    @RequestMapping(value = { "", "/" })
+    public String listTemplates(Model model, @RequestParam(value = "page", defaultValue = "1") int page, @RequestParam(
+            value = "items", defaultValue = "10") int items) {
+        List<MessageTemplateDescriptionBean> templates =
+                MessagingSystem.getUndeclaredTemplates().stream().map(t -> new MessageTemplateDescriptionBean(t))
+                        .collect(Collectors.toList());
+        MessagingSystem.getTemplateDeclarations().values().forEach(d -> templates.add(new MessageTemplateDescriptionBean(d)));
+        templates.sort(MessageTemplateDescriptionBean.COMPARATOR_BY_ID);
+        PaginationUtils.paginate(model, "templates", templates, items, page);
+        return "messaging/listTemplates";
+    }
+
+    @RequestMapping("/{template}")
+    public ModelAndView viewTemplate(@PathVariable MessageTemplate template) throws Exception {
+        MessageTemplateDeclaration decl = MessagingSystem.getTemplateDeclaration(template.getId());
+
+        Set<Locale> locales = new HashSet<Locale>(CoreConfiguration.supportedLocales());
+        LocalizedString content = template.getTextBody();
+        if (content != null) {
+            locales.addAll(content.getLocales());
+        }
+        content = template.getHtmlBody();
+        if (content != null) {
+            locales.addAll(content.getLocales());
+        }
+
+        return new ModelAndView("messaging/viewTemplate", ImmutableMap.of("templateLocales", locales, "template", decl));
+    }
+
+    @RequestMapping("/{template}/edit")
+    public String editTemplate(Model model, @PathVariable MessageTemplate template,
+            @ModelAttribute("templateBean") MessageBodyBean bean) throws Exception {
+        bean.copy(template);
+        model.addAttribute("template", MessagingSystem.getTemplateDeclaration(template.getId()));
+        model.addAttribute("templateBean", bean);
+        return "messaging/editTemplate";
+    }
+
+    @RequestMapping("/{template}/reset")
+    public String resetTemplate(Model model, @PathVariable MessageTemplate template) throws Exception {
+        MessageTemplateDeclaration decl = MessagingSystem.getTemplateDeclaration(template.getId());
+        model.addAttribute("template", decl);
+        model.addAttribute("templateBean", new MessageBodyBean(decl));
+        return "messaging/editTemplate";
+    }
+
+    @RequestMapping(value = "/{template}/edit", method = RequestMethod.POST)
+    public ModelAndView saveTemplate(Model model, @PathVariable MessageTemplate template,
+            @ModelAttribute("templateBean") MessageBodyBean bean) throws Exception {
+        if (bean.edit(template)) {
+            return viewTemplate(template);
+        }
+        model.addAttribute("template", MessagingSystem.getTemplateDeclaration(template.getId()));
+        model.addAttribute("templateBean", bean);
+        return new ModelAndView("messaging/editTemplate", model.asMap());
+    }
+}

--- a/core/src/main/resources/META-INF/services/javax.servlet.ServletContainerInitializer
+++ b/core/src/main/resources/META-INF/services/javax.servlet.ServletContainerInitializer
@@ -1,0 +1,1 @@
+org.fenixedu.messaging.template.MessageTemplateDeclarationInitializer

--- a/core/src/main/resources/MessagingResources_en.properties
+++ b/core/src/main/resources/MessagingResources_en.properties
@@ -1,15 +1,17 @@
 error.bootstrapper.systemsender.address.empty = Sender address is required.
 error.bootstrapper.systemsender.group.empty = Sender group is required.
 error.bootstrapper.systemsender.name.empty = Sender name is required.
+error.message.null.sender = Attempt to send a message without a sender.
 error.message.validation.bcc.invalid = E-mail address is not valid: {0}.
-error.message.validation.message.empty = Message is required.
+error.message.validation.message.empty = Message body is required.
 error.message.validation.html.forbidden = This sender is not allowed to send HTML messages.
 error.message.validation.recipients.empty = At least one recipient is required.
 error.message.validation.subject.empty = Subject is required.
 error.message.validation.sender.empty = Sender is required.
-error.message.validation.recipient.erroneous = A recipient expression could not be understood: {0}. 
+error.message.validation.recipient.erroneous = A recipient expression could not be understood: {0}.
 error.not.authorized = You do not have permission to view this page
-error.not.found = The requested page was not found
+error.template.malformed = Message template with id "{0}" could not be compiled.
+error.template.missing = Message template with id "{0}" could not be found.
 
 hint.bootstrapper.systemsender.address = noreply@organization.com
 hint.bootstrapper.systemsender.group = #managers
@@ -19,7 +21,13 @@ label.bootstrapper.systemsender.address = Address
 label.bootstrapper.systemsender.group = Sender Group
 label.bootstrapper.systemsender.name = Name
 
-message.footer = \n\n---\nThis message was sent by {0}, to the following recipients:\n\t{1}
+message.template.message.wrapper.description = Wraps institutional messages sent via the message sending interface.
+message.template.message.wrapper.html =
+message.template.message.wrapper.parameter.htmlContent = The HTML content of the message.
+message.template.message.wrapper.parameter.recipients = The message's group recipients.
+message.template.message.wrapper.parameter.sender = Name of the message sender.
+message.template.message.wrapper.parameter.textContent = The plain text content of the message.
+message.template.message.wrapper.text = {{textContent}}\n\n---\nThis message was sent by {{sender}}, to the following recipients:{% for recipient in recipients %}\n\t{{recipient}}{% endfor %}
 
 name.deletion.policy.messages = up to {0} messages
 name.deletion.policy.period = for {0}

--- a/core/src/main/resources/MessagingResources_pt.properties
+++ b/core/src/main/resources/MessagingResources_pt.properties
@@ -1,15 +1,17 @@
 error.bootstrapper.systemsender.address.empty = Endereço do remetente é necessário.
 error.bootstrapper.systemsender.name.empty = Nome do remetente é necessário.
 error.bootstrapper.systemsender.group.empty = Grupo de envio é necessário.
+error.message.null.sender = Tentativa de envio de mensagem sem remetente.
 error.message.validation.bcc.invalid = Endereço de e-mail não é válido: {0}.
-error.message.validation.message.empty = Mensagem é necessária.
+error.message.validation.message.empty = Corpo da mensagem é necessário.
 error.message.validation.html.forbidden = Este remetente não está autorizado a enviar mensagens HTML.
 error.message.validation.recipients.empty = É necessário pelo menos um destinatário.
 error.message.validation.subject.empty = Assunto é necessário.
 error.message.validation.sender.empty = Remetente é necessário.
 error.message.validation.recipient.erroneous = Uma expressão de destinatário não foi compreendida: {0}.
 error.not.authorized = Não tem permissões para ver esta página
-error.not.found = A página pedida não foi encontrada
+error.template.malformed = Não foi possível compilar a template de mensagem com id "{0}".
+error.template.missing = Não foi possível encontrar a template de mensagem com id "{0}".
 
 hint.bootstrapper.systemsender.address = noreply@organization.com
 hint.bootstrapper.systemsender.group = #managers
@@ -19,7 +21,13 @@ label.bootstrapper.systemsender.address = Endereço
 label.bootstrapper.systemsender.group = Grupo de Envio
 label.bootstrapper.systemsender.name = Nome
 
-message.footer = \n\n---\nEsta mensagem foi enviada em nome do(a) {0}, para os seguintes destinatários:\n\t{1}
+message.template.message.wrapper.description = Envolve mensagens institucionais enviadas através da interface de envio de mensagens.
+message.template.message.wrapper.html =
+message.template.message.wrapper.parameter.htmlContent = O conteúdo HTML da mensagem.
+message.template.message.wrapper.parameter.recipients = Os grupos de destinatários da mensagem.
+message.template.message.wrapper.parameter.sender = O nome do remetente da mensagem.
+message.template.message.wrapper.parameter.textContent = O conteúdo textual simples da mensagem.
+message.template.message.wrapper.text = {{textContent}}\n\n---\nEsta mensagem foi enviada em nome do(a) {{sender}}, para os seguintes destinatários:{% for recipient in recipients %}\n\t{{recipient}}{% endfor %}
 
 name.deletion.policy.messages = até {0} mensagens
 name.deletion.policy.period = for {0}

--- a/core/src/main/webapp/WEB-INF/messaging/editTemplate.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/editTemplate.jsp
@@ -1,0 +1,88 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://www.springframework.org/tags" prefix="spring"%>
+<%@ taglib uri="http://www.springframework.org/tags/form" prefix="form"%>
+
+${portal.toolkit()}
+
+<h2><spring:message code="title.template.edit"/></h2>
+
+<c:if test="${not empty templateBean.errors}">
+	<div class="alert alert-danger">
+		<span><spring:message code="error.template.not.saved"/></span>
+		<c:forEach items="${templateBean.errors}" var="error">
+			<br/><span style="padding-left: 2em;">${error}</span>
+		</c:forEach>
+	</div>
+</c:if>
+
+<form:form modelAttribute="templateBean" role="form" class="form-horizontal" action="${pageContext.request.contextPath}/messaging/config/templates/${template.externalId}/edit" method="post">
+	<div class="collapse form-group template-info">
+		<label class="control-label col-sm-2"><spring:message code="label.template.id"/></label>
+		<div class="col-sm-10" style="padding-top: 7px;">
+			<code>${template.id}</code>
+		</div>
+	</div>
+	<div class="collapse form-group template-info">
+		<label class="control-label col-sm-2"><spring:message code="label.template.description"/></label>
+		<div class="col-sm-10" style="padding-top: 7px;">
+			${template.description.content}
+		</div>
+	</div>
+	<c:if test="${not empty template.parameters}">
+	<div class="collapse form-group template-info">
+		<label class="control-label col-sm-2"><spring:message code="label.template.parameters"/></label>
+		<div class="col-sm-10">
+			<ul class="list-unstyled">
+			<c:forEach items="${template.parameters}" var="entry">
+				<li><em>${entry.key}</em>: ${entry.value.content}</li>
+			</c:forEach>
+			</ul>
+		</div>
+	</div>
+	</c:if>
+	<div class="form-group">
+		<label class="control-label col-sm-2" for="textBody"><spring:message code="label.message.body"/>:</label>
+		<div class="col-sm-10">
+			<textarea class="form-control" id="textBody" name="textBody" bennu-localized-string>${templateBean.textBody.json()}</textarea>
+		</div>
+	</div>
+	<div class="form-group">
+		<label class="control-label col-sm-2" for="htmlBody"><spring:message code="label.message.body.html"/>:</label>
+		<div class="col-sm-10">
+			<textarea class="form-control" id="htmlBody" name="htmlBody" bennu-html-editor bennu-localized-string/>${templateBean.htmlBody.json()}</textarea>
+		</div>
+	</div>
+	<div class="form-group">
+		<div class="col-sm-offset-2 col-sm-10 btn-group">
+				<button class="btn btn-primary" type="submit"><spring:message code="action.template.save"/></button>
+				<div class="btn-group">
+					<button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+						<spring:message code="label.actions"/>
+						<span class="caret"></span>
+					</button>
+					<ul class="dropdown-menu dropdown-menu-right">
+						<li><a href="reset"><spring:message code="action.template.reset"/></a></li>
+						<li id="showInfo"><a data-toggle="collapse" href=".template-info"><spring:message code="action.template.info.show"/></a></li>
+						<li id="hideInfo"><a data-toggle="collapse" href=".template-info"><spring:message code="action.template.info.hide"/></a></li>
+					</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+</form:form>
+<script>
+(function(){
+	var show = $('#showInfo'),
+		hide = $('#hideInfo');
+	show.click(function() {
+		hide.show();
+		show.hide();
+	});
+	hide.click(function() {
+		hide.hide();
+		show.show();
+	});
+	hide.hide();
+})();
+</script>

--- a/core/src/main/webapp/WEB-INF/messaging/listSenders.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/listSenders.jsp
@@ -8,10 +8,10 @@
 		<thead>
 			<tr>
 				<th>
-					<spring:message code="label.bootstrapper.systemsender.name"/>
+					<spring:message code="label.sender.name"/>
 				</th>
 				<th>
-					<spring:message code="label.bootstrapper.systemsender.address"/>
+					<spring:message code="label.sender.address"/>
 				</th>
 				<th></th>
 			</tr>

--- a/core/src/main/webapp/WEB-INF/messaging/listTemplates.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/listTemplates.jsp
@@ -1,0 +1,83 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://www.springframework.org/tags" prefix="spring"%>
+
+<h2><spring:message code="title.templates.config"/></h2>
+<c:if test="${not empty templates}">
+	<table class="table table-hover table-condensed">
+		<thead>
+			<tr>
+				<th>
+					<spring:message code="label.template.id"/>
+				</th>
+				<th>
+					<spring:message code="label.template.description"/>
+				</th>
+				<th></th>
+			</tr>
+		</thead>
+		<tbody>
+		<c:forEach items="${templates}" var="template">
+			<c:choose>
+			<c:when test="${empty template.description}">
+			<spring:message code="error.template.undeclared" var="tooltip"/>
+			<tr class="danger" data-toggle="tooltip" data-placement="left" title="${tooltip}"
+			</c:when>
+			<c:when test="${template.error}">
+			<spring:message code="notification.template.empty" var="tooltip"/>
+			<tr class="warning" data-toggle="tooltip" data-placement="left" title="${tooltip}"
+			</c:when>
+			<c:otherwise><tr</c:otherwise>
+			</c:choose>
+				onClick="location.href='${pageContext.request.contextPath}/messaging/config/templates/${template.externalId}'">
+				<td class="col-sm-2">
+					<code>${template.id}</code>
+				</td>
+				<td class="col-sm-7">
+					${template.description.content}
+				</td>
+				<td class="col-sm-3">
+					<div class="btn-group btn-group-xs pull-right">
+						<a class="btn btn-primary" href="${pageContext.request.contextPath}/messaging/config/templates/${template.externalId}/edit">
+							<spring:message code="action.template.edit"/>
+						</a>
+						<a class="btn btn-default" href="${pageContext.request.contextPath}/messaging/config/templates/${template.externalId}">
+							<spring:message code="action.view.details"/>
+						</a>
+					</div>
+				</td>
+			</tr>
+		</c:forEach>
+		</tbody>
+		<c:if test="${pages>1}">
+			<tfoot>
+				<tr>
+					<td colspan="4" style="text-align: center;">
+						<nav style="display:inline-block;">
+							<ul class="pagination">
+								<c:if test="${page == 1}"><li class="disabled"></c:if>
+								<c:if test="${page > 1}"><li></c:if>
+									<a href="${pageContext.request.contextPath}/messaging/config/templates?page=${page-1}&items=${items}"><span>&laquo;</span></a>
+								</li>
+								<c:forEach begin="1" end="${pages}" var="p" >
+									<c:if test="${p == page}"><li class="active"></c:if>
+									<c:if test="${p != page}"><li></c:if>
+								<a href="${pageContext.request.contextPath}/messaging/config/templates?page=${p}&items=${items}">${p}</a></li>
+								</c:forEach>
+								<c:if test="${page == pages}"><li class="disabled"></c:if>
+								<c:if test="${page < pages}"><li></c:if>
+									<a href="${pageContext.request.contextPath}/messaging/config/templates?page=${page+1}&items=${items}"><span>&raquo;</span></a>
+								</li>
+							</ul>
+						</nav>
+					</td>
+				</tr>
+			</tfoot>
+		</c:if>
+	</table>
+	<script>
+	(function () {
+	  $('[data-toggle="tooltip"]').tooltip()
+	})();
+	</script>
+</c:if>

--- a/core/src/main/webapp/WEB-INF/messaging/newMessage.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/newMessage.jsp
@@ -16,7 +16,6 @@ ${portal.toolkit()}
 	</div>
 </c:if>
 
-<br/>
 <spring:eval expression="T(org.fenixedu.messaging.domain.Sender).getAvailableSenders()" var="senders"/>
 <form:form modelAttribute="messageBean" role="form" class="form-horizontal" action="${pageContext.request.contextPath}/messaging/message" method="post">
 	<div class="form-group">
@@ -72,7 +71,7 @@ ${portal.toolkit()}
 	<div class="form-group">
 		<label class="control-label col-sm-2" for="body"><spring:message code="label.message.body"/>:</label>
 		<div class="col-sm-10">
-			<textarea class="form-control" id="body" name="body" bennu-localized-string>${messageBean.body.json()}</textarea>
+			<textarea class="form-control" id="body" name="textBody" bennu-localized-string>${messageBean.textBody.json()}</textarea>
 		</div>
 	</div>
 	<div id="htmlMessage" class="form-group">

--- a/core/src/main/webapp/WEB-INF/messaging/viewSender.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/viewSender.jsp
@@ -8,7 +8,7 @@
 	<tbody>
 		<tr>
 			<th class="col-md-2" scope="row">
-				<spring:message code="label.bootstrapper.systemsender.name"/>
+				<spring:message code="label.sender.name"/>
 			</th>
 			<td>
 				${sender.fromName}
@@ -16,7 +16,7 @@
 		</tr>
 		<tr>
 			<th class="col-md-2" scope="row">
-				<spring:message code="label.bootstrapper.systemsender.address"/>
+				<spring:message code="label.sender.address"/>
 			</th>
 			<td>
 				<code>${sender.fromAddress}</code>

--- a/core/src/main/webapp/WEB-INF/messaging/viewTemplate.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/viewTemplate.jsp
@@ -1,0 +1,112 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
+<%@ taglib uri="http://www.springframework.org/tags" prefix="spring"%>
+
+${portal.toolkit()}
+
+<h2><spring:message code="title.template"/></h2>
+
+<c:choose>
+<c:when test="${template.htmlBody.isEmpty() and template.textBody.isEmpty()}">
+	<p class="alert alert-warning"><spring:message code="notification.template.empty"/></p>
+</c:when>
+</c:choose>
+
+<a class="btn btn-primary" href="${pageContext.request.contextPath}/messaging/config/templates/${template.externalId}/edit">
+	<spring:message code="action.template.edit"/>
+</a>
+<table class="table table-condensed">
+	<tbody>
+		<tr>
+			<th class="col-md-2" scope="row">
+				<spring:message code="label.template.id"/>
+			</th>
+			<td>
+					<code>${template.id}</code>
+			</td>
+		</tr>
+		<tr>
+			<th class="col-md-2" scope="row">
+				<spring:message code="label.template.description"/>
+			</th>
+			<td>
+				${template.description.content}
+			</td>
+		</tr>
+		<c:if test="${not empty template.parameters}">
+		<tr>
+			<th class="col-md-2" scope="row">
+				<spring:message code="label.template.parameters"/>
+			</th>
+			<td>
+				<ul class="list-unstyled">
+				<c:forEach items="${template.parameters}" var="entry">
+					<li><em>${entry.key}</em>: ${entry.value.content}</li>
+				</c:forEach>
+				</ul>
+			</td>
+		</tr>
+		</c:if>
+		<c:if test="${not template.htmlBody.isEmpty() or not template.textBody.isEmpty()}">
+		<tr>
+			<th class="col-md-2" scope="row">
+				<spring:message code="label.message.locale"/>
+			</th>
+			<td>
+				<ul class="nav nav-pills">
+				<c:forEach items="${templateLocales}" var="locale">
+					<li><a class="btn-sm localized" id="locale-${locale}">${locale.getDisplayName(locale)}</a></li>
+				</c:forEach>
+				</ul>
+			</td>
+		</tr>
+		</c:if>
+		<c:if test="${not template.textBody.isEmpty()}">
+		<tr>
+			<th class="col-md-2" scope="row">
+				<spring:message code="label.message.body"/>
+			</th>
+			<td>
+			<c:forEach items="${templateLocales}" var="locale">
+				<div class="panel panel-default localized locale-${locale}" style="margin:0;">
+					<div style="white-space: pre-wrap;" class="panel-heading"><c:out value="${template.textBody.getContent(locale)}" default="${template.textBody.getContent()}"/></div>
+				</div>
+			</c:forEach>
+			</td>
+		</tr>
+		</c:if>
+		<c:if test="${not template.htmlBody.isEmpty()}">
+		<tr>
+			<th class="col-md-2" scope="row">
+				<spring:message code="label.message.body.html"/>
+			</th>
+			<td>
+			<c:forEach items="${templateLocales}" var="locale">
+				<div class="panel panel-default localized locale-${locale}" style="margin:0;">
+					<div style="white-space: pre-wrap;" class="panel-heading"><c:out value="${template.htmlBody.getContent(locale)}" default="${template.htmlBody.getContent()}" escapeXml="false"/></div>
+				</div>
+			</c:forEach>
+			</td>
+		</tr>
+		</c:if>
+	</tbody>
+</table>
+<script>
+(function() {
+	var pills=$("a.localized");
+	var content=$("div.localized");
+	function selectLocale(locale){
+		pills.parent().removeClass("active");
+		$("#"+locale).parent().addClass("active");
+		content.hide();
+		$("div."+locale).show();
+	}
+	pills.click(function(event){
+		selectLocale($(event.target).attr('id'));
+	})
+	var firstLocale="<c:forEach items="${templateLocales}" var="locale" end="0">locale-<c:out value="${locale}"/></c:forEach>";
+	selectLocale(firstLocale);
+})();
+</script>

--- a/core/src/main/webapp/WEB-INF/resources/MessagingResources_en.properties
+++ b/core/src/main/webapp/WEB-INF/resources/MessagingResources_en.properties
@@ -1,13 +1,21 @@
 action.message.delete = Delete
 action.message.new = New Message
 action.message.send = Send
+action.template.edit = Edit
+action.template.reset = Restore Defaults
+action.template.save = Save
+action.template.info.show = Show Description
+action.template.info.hide = Hide Description
 action.view.details = View Details
 
 error.message.not.sent = Message could not be sent:
+error.template.not.saved = Message template could not be saved:
+error.template.undeclared = Message template is undeclared.
 
 hint.sender.select = Select a sender
 hint.extra.bccs = someone@example.com, ...
 
+label.actions = Other Actions
 label.message.bccs = Recipients (Bcc)
 label.message.bccs.extra = Other Recipients (Bcc)
 label.message.bccs.extra.locale = Other Recipients Locale
@@ -16,6 +24,7 @@ label.message.body.html = HTML Message
 label.message.ccs = Recipients (Cc)
 label.message.created = Created
 label.message.locale = Content Locales
+label.no = No
 label.message.replyTos = Reply to
 label.message.sender = Sender
 label.message.sender.name = Sender Name
@@ -27,18 +36,31 @@ label.message.status.sent = Sent
 label.message.sent.by = Sent by
 label.message.subject = Subject
 label.message.tos = Recipients (To)
-label.bootstrapper.systemsender.address = Address
-label.bootstrapper.systemsender.group = Sender Group
-label.bootstrapper.systemsender.name = Name
+label.sender.address = Address
+label.sender.group = Sender Group
+label.sender.name = Name
 label.sender.policy = Message Storage Policy
 label.sender.replyTos = Reply to
+label.template.description = Description
+label.template.footer = Automatic Footer
+label.template.id = Key
+label.template.name = Name
+label.template.parameters = Parameters
+label.yes = Yes
 
 notification.message.sent = This message has been queued for sending. While it is not dispatched you may delete it, canceling the process.
+notification.template.empty = This message template is empty. Attempts to send it will fail reporting an error.
+notification.template.subject.empty = This message template's subject is empty. Attempts to send it will fail reporting an error.
+notification.template.message.empty = This message template's body is empty. Attempts to send it will fail reporting an error.
 
 title.message = Message
 title.message.new = New Message
 title.messages = Messages
 title.messaging = Messaging System
 title.messaging.sending = Message Sending
+title.messaging.templates = Template Configuration
 title.sender = Sender Information
 title.senders = Senders
+title.templates.config = Message Template Configuration
+title.template = Message Template
+title.template.edit = Edit Message Template

--- a/core/src/main/webapp/WEB-INF/resources/MessagingResources_pt.properties
+++ b/core/src/main/webapp/WEB-INF/resources/MessagingResources_pt.properties
@@ -1,13 +1,21 @@
 action.message.delete = Eliminar
 action.message.new = Nova Mensagem
 action.message.send = Enviar
+action.template.edit = Editar
+action.template.reset = Restaurar Conteúdo Padrão
+action.template.save = Guardar
+action.template.info.show = Ver Parâmetros
+action.template.info.hide = Esconder Parâmetros
 action.view.details = Ver Detalhes
 
 error.message.not.sent = Mensagem não pôde ser enviada:
+error.template.not.saved = Modelo de mensagem não pode ser guardado:
+error.template.undeclared = Modelo de mensagem não foi declarado.
 
 hint.sender.select = Seleccione um remetente
 hint.extra.bccs = alguem@exemplo.pt, ...
 
+label.Actions = Outras Acções
 label.message.bccs = Destinatários (Bcc)
 label.message.bccs.extra = Outros Destinatários (Bcc)
 label.message.bccs.extra.locale = Localização para Outros Destinatários
@@ -16,6 +24,7 @@ label.message.body.html = Mensagem HTML
 label.message.ccs = Destinatários (Cc)
 label.message.created = Criado
 label.message.locale = Localizações do Conteúdo
+label.no = Não
 label.message.replyTos = Responder a
 label.message.sender = Remetente
 label.message.sender.name = Nome do Remetente
@@ -27,18 +36,31 @@ label.message.status.sent = Enviado
 label.message.sent.by = Enviado por
 label.message.subject = Assunto
 label.message.tos = Destinatários (To)
-label.bootstrapper.systemsender.address = Endereço
-label.bootstrapper.systemsender.group = Grupo de Envio
-label.bootstrapper.systemsender.name = Nome
+label.sender.address = Endereço
+label.sender.group = Grupo de Envio
+label.sender.name = Nome
 label.sender.policy = Política de Preservação de Mensagens
 label.sender.replyTos = Responder a
+label.template.description = Descrição
+label.template.footer = Rodapé Automático
+label.template.id = Chave
+label.template.name = Nome
+label.template.parameters = Parâmetros
+label.yes = Sim
 
 notification.message.sent = Esta mensagem está pendente para envio. Enquanto não for enviada poderá apagá-la, cancelando o processo.
+notification.template.empty = Este modelo de mensagem encontra-se vazio. Tentativas de envio irão falhar reportando um erro.
+notification.template.subject.empty = O assunto deste modelo de mensagem encontra-se vazio. Tentativas de envio irão falhar reportando um erro.
+notification.template.message.empty = A mensagem deste modelo de mensagem encontra-se vazia. Tentativas de envio irão falhar reportando um erro.
 
 title.message = Mensagem
 title.message.new = Nova Mensagem
 title.messages = Mensagens
 title.messaging = Sistema de Mensagens
 title.messaging.sending = Envio de Mensagens
+title.messaging.templates = Configuração de Modelos de Mensagem
 title.sender = Informação do Remetente
 title.senders = Remetentes
+title.templates.config = Configuração de Modelos de Mensagem
+title.template = Modelo de Mensagem
+title.template.edit = Editar Modelo de Mensagem


### PR DESCRIPTION
Message templates are localizable and use pebble as a templating language.
LocalizedString arguments are localized automatically when sending the
message. The templates are defined via annotation to be registered on
servlet container initialization. This annotation allows initializing the
template content through the .properties files and the messaging
configuration interface allows editing the templates' contents in
production.
The institutional footer with recipient descrimination was converted to a
template that wraps any message sent via the interface and can now be
edited in production.
Minor changes and corrections were made to message sending, mostly related
to exception throwing, and to the messaging interfaces.

Closes #7.