### PR TITLE
improve email-dispatch and fix various bugs

### DIFF
--- a/core/src/main/java/org/fenixedu/messaging/ui/MessageBean.java
+++ b/core/src/main/java/org/fenixedu/messaging/ui/MessageBean.java
@@ -112,18 +112,11 @@ public class MessageBean extends MessageContentBean {
     }
 
     public String getBccs() {
-        if (bccs != null) {
-            return MessagingSystem.MAIL_LIST_JOINER.join(bccs);
-        }
-        return null;
+        return MessagingSystem.Util.toEmailListString(bccs);
     }
 
     public void setBccs(String bccs) {
-        if (bccs != null) {
-            this.bccs = MessagingSystem.toEmailSet(bccs).stream().filter(s -> !s.isEmpty()).collect(Collectors.toSet());
-        } else {
-            this.bccs = null;
-        }
+        this.bccs = MessagingSystem.Util.toEmailSet(bccs);
     }
 
     public Set<String> getBccsSet() {

--- a/core/src/main/java/org/fenixedu/messaging/ui/MessageSendingUrlBuilder.java
+++ b/core/src/main/java/org/fenixedu/messaging/ui/MessageSendingUrlBuilder.java
@@ -43,10 +43,7 @@ public class MessageSendingUrlBuilder {
     }
 
     public MessageSendingUrlBuilder bccs(String bccs) {
-        builder.queryParam(
-                "bccs",
-                MessagingSystem.toEmailSet(bccs).stream().filter(s -> !Strings.isNullOrEmpty(s))
-                        .map(MessageSendingUrlBuilder::encode).toArray());
+        builder.queryParam("bccs", MessagingSystem.Util.toEmailSet(bccs).stream().map(MessageSendingUrlBuilder::encode).toArray());
         return this;
     }
 

--- a/core/src/main/java/org/fenixedu/messaging/ui/SenderBean.java
+++ b/core/src/main/java/org/fenixedu/messaging/ui/SenderBean.java
@@ -5,14 +5,11 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
-
-import org.apache.commons.validator.routines.EmailValidator;
 import org.fenixedu.bennu.core.domain.exceptions.BennuCoreDomainException;
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.i18n.BundleUtil;
 import org.fenixedu.messaging.domain.MessageDeletionPolicy;
+import org.fenixedu.messaging.domain.MessagingSystem;
 import org.fenixedu.messaging.domain.Sender;
 
 import pt.ist.fenixframework.Atomic;
@@ -34,7 +31,7 @@ public class SenderBean {
         if (Strings.isNullOrEmpty(address)) {
             errors.add(BundleUtil.getString(BUNDLE, "error.sender.validation.address.empty"));
         }
-        if (!EmailValidator.getInstance().isValid(address)) {
+        if (!MessagingSystem.Util.isValidEmail(address)) {
             errors.add(BundleUtil.getString(BUNDLE, "error.sender.validation.address.invalid"));
         }
         if (getHtmlSender() == null) {
@@ -72,12 +69,8 @@ public class SenderBean {
             }
         }
         String replyTo = getReplyTo();
-        if (!Strings.isNullOrEmpty(replyTo)) {
-            try {
-                new InternetAddress(replyTo, true);
-            } catch (AddressException e) {
-                errors.add(BundleUtil.getString(BUNDLE, "error.sender.validation.replyTo.invalid", replyTo));
-            }
+        if (!(Strings.isNullOrEmpty(replyTo) || MessagingSystem.Util.isValidEmail(replyTo))) {
+            errors.add(BundleUtil.getString(BUNDLE, "error.sender.validation.replyTo.invalid", replyTo));
         }
         setErrors(errors);
         return errors;

--- a/core/src/main/resources/MessagingResources_en.properties
+++ b/core/src/main/resources/MessagingResources_en.properties
@@ -40,7 +40,7 @@ message.template.message.wrapper.parameter.sender = Name of the message sender.
 message.template.message.wrapper.parameter.textContent = The plain text content of the message.
 message.template.message.wrapper.parameter.subjectContent = The content of the message subject.
 message.template.message.wrapper.subject = {{subjectContent}}
-message.template.message.wrapper.text = {{textContent}}\n\n---\nThis message was sent by {{sender}}, to the following recipients:{% for recipient in recipients %}\n\t{{recipient}}{% endfor %}
+message.template.message.wrapper.text = {{textContent}}\n\n---\nThis message was sent by {{sender}}, to the following recipients:{% for recipient in recipients %}\n\n\t{{recipient}}{% endfor %}
 
 name.deletion.policy.messages = up to {0} messages
 name.deletion.policy.period = for {0}

--- a/core/src/main/resources/MessagingResources_pt.properties
+++ b/core/src/main/resources/MessagingResources_pt.properties
@@ -40,7 +40,7 @@ message.template.message.wrapper.parameter.sender = O nome do remetente da mensa
 message.template.message.wrapper.parameter.textContent = O conteúdo textual simples da mensagem.
 message.template.message.wrapper.parameter.subjectContent = O conteúdo do assunto da mensagem.
 message.template.message.wrapper.subject = {{subjectContent}}
-message.template.message.wrapper.text = {{textContent}}\n\n---\nEsta mensagem foi enviada em nome do(a) {{sender}}, para os seguintes destinatários:{% for recipient in recipients %}\n\t{{recipient}}{% endfor %}
+message.template.message.wrapper.text = {{textContent}}\n\n---\nEsta mensagem foi enviada em nome do(a) {{sender}}, para os seguintes destinatários:{% for recipient in recipients %}\n\n\t{{recipient}}{% endfor %}
 
 name.deletion.policy.messages = até {0} mensagens
 name.deletion.policy.period = durante {0}

--- a/core/src/main/webapp/WEB-INF/messaging/viewMessage.jsp
+++ b/core/src/main/webapp/WEB-INF/messaging/viewMessage.jsp
@@ -104,42 +104,42 @@ ${portal.toolkit()}
 				</td>
 			</tr>
 		</c:if>
-		<c:if test="${not empty message.toGroup}">
+		<c:if test="${not empty message.toGroups}">
 			<tr>
 				<th class="col-md-2" scope="row">
 					<spring:message code="label.message.tos"/>
 				</th>
 				<td>
 					<div style="overflow-y:auto; max-height:85px; display:block;">
-					<c:forEach items="${message.toGroup}" var="to">
+					<c:forEach items="${message.toGroups}" var="to">
 						<code style="display: inline-block; margin: 2px;">${to.presentationName}</code>
 					</c:forEach>
 					</div>
 				</td>
 			</tr>
 		</c:if>
-		<c:if test="${not empty message.ccGroup}">
+		<c:if test="${not empty message.ccGroups}">
 			<tr>
 				<th class="col-md-2" scope="row">
 					<spring:message code="label.message.ccs"/>
 				</th>
 				<td>
 					<div style="overflow-y:auto; max-height:85px; display:block;">
-					<c:forEach items="${message.ccGroup}" var="cc">
+					<c:forEach items="${message.ccGroups}" var="cc">
 						<code style="display: inline-block; margin: 2px;">${cc.presentationName}</code>
 					</c:forEach>
 					</div>
 				</td>
 			</tr>
 		</c:if>
-		<c:if test="${not empty message.bccGroup}">
+		<c:if test="${not empty message.bccGroups}">
 			<tr>
 				<th class="col-md-2" scope="row">
 					<spring:message code="label.message.bccs"/>
 				</th>
 				<td>
 					<div style="overflow-y:auto; max-height:85px; display:block;">
-					<c:forEach items="${message.bccGroup}" var="bcc">
+					<c:forEach items="${message.bccGroups}" var="bcc">
 						<code style="display: inline-block; margin: 2px;">${bcc.presentationName}</code>
 					</c:forEach>
 					</div>

--- a/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/EmailDispatchConfiguration.java
+++ b/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/EmailDispatchConfiguration.java
@@ -22,6 +22,12 @@ public class EmailDispatchConfiguration {
         @ConfigurationProperty(key = "mailingList.host.name")
         public String mailingListHostName();
 
+        @ConfigurationProperty(
+                key = "mailSender.bcc.recipients",
+                defaultValue = "false",
+                description = "If true, To and Cc recipients will be treated as Bcc recipients. The dispatcher does not guarantee the visibility of these types of recipients in sent emails. This flag exists for the cases where it may be preferable to guarantee that none are visible.")
+        public Boolean recipientsAsBccs();
+
     }
 
     public static ConfigurationProperties getConfiguration() {

--- a/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/EmailTask.java
+++ b/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/EmailTask.java
@@ -33,8 +33,6 @@ import org.fenixedu.messaging.emaildispatch.domain.LocalEmailMessageDispatchRepo
 public class EmailTask extends CronTask {
     @Override
     public void runTask() throws Exception {
-        for (LocalEmailMessageDispatchReport report : MessagingSystem.getInstance().getUnfinishedReportsSet()) {
-            report.deliver();
-        }
+        MessagingSystem.getInstance().getUnfinishedReportsSet().forEach(LocalEmailMessageDispatchReport::deliver);
     }
 }

--- a/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/domain/LocalEmailMessageDispatchReport.java
+++ b/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/domain/LocalEmailMessageDispatchReport.java
@@ -1,16 +1,26 @@
 package org.fenixedu.messaging.emaildispatch.domain;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.mail.MessagingException;
 
+import org.fenixedu.bennu.core.domain.User;
+import org.fenixedu.bennu.core.domain.UserProfile;
+import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.messaging.domain.Message;
 import org.fenixedu.messaging.domain.MessagingSystem;
+import org.fenixedu.messaging.emaildispatch.EmailDispatchConfiguration;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,13 +28,16 @@ import org.slf4j.LoggerFactory;
 import pt.ist.fenixframework.Atomic;
 import pt.ist.fenixframework.Atomic.TxMode;
 
+import com.google.common.collect.Maps;
+
 public class LocalEmailMessageDispatchReport extends LocalEmailMessageDispatchReport_Base {
     private static final Logger logger = LoggerFactory.getLogger(LocalEmailMessageDispatchReport.class);
+    private static final boolean RECIPIENTS_AS_BCCS = EmailDispatchConfiguration.getConfiguration().recipientsAsBccs();
 
-    public LocalEmailMessageDispatchReport(Set<MimeMessageHandler> handlers, Integer totalCount, Integer invalidCount) {
+    public LocalEmailMessageDispatchReport(Collection<MimeMessageHandler> handlers, Integer validCount, Integer invalidCount) {
         super();
         getHandlerSet().addAll(handlers);
-        setTotalCount(totalCount);
+        setTotalCount(validCount + invalidCount);
         setDeliveredCount(0);
         setFailedCount(0);
         setInvalidCount(invalidCount);
@@ -61,59 +74,79 @@ public class LocalEmailMessageDispatchReport extends LocalEmailMessageDispatchRe
         setQueue(null);
     }
 
+    public static LocalEmailMessageDispatchReport dispatch(Message message) {
+        List<String> invalids = new ArrayList<String>();
+        EmailBlacklist blacklist = EmailBlacklist.getInstance();
+        Predicate<String> validator = email -> {
+            boolean valid = MessagingSystem.Util.isValidEmail(email);
+            if (!valid) {
+                invalids.add(email);
+            }
+            return valid;
+        };
+        Set<UserProfile> tos = getProfiles(message.getToGroups()), ccs = getProfiles(message.getCcGroups()), bccs =
+                getProfiles(message.getBccGroups());
+        Collection<MimeMessageHandler> handlers;
+        int valids;
+
+        Map<Locale, Set<String>> tosByLocale, ccsByLocale, bccsByLocale;
+        Locale defLocale = message.getExtraBccsLocale();
+
+        if (RECIPIENTS_AS_BCCS) {
+            bccs.addAll(tos);
+            bccs.addAll(ccs);
+
+            tosByLocale = Maps.newHashMap();
+            ccsByLocale = Maps.newHashMap();
+            bccsByLocale = emailsByPreferredLocale(bccs, validator, defLocale);
+            Set<String> extraBccs = message.getExtraBccsSet().stream().filter(validator).collect(Collectors.toSet());
+            bccsByLocale.computeIfAbsent(message.getExtraBccsLocale(), k -> new HashSet<>()).addAll(extraBccs);
+        } else {
+            //XXX force disjoint recipient lists - priority order: tos > ccs > bccs > email bccs
+            ccs.removeAll(tos);
+            bccs.removeAll(tos);
+            bccs.removeAll(ccs);
+            Set<String> extraBccs = message.getExtraBccsSet();
+            tos.stream().map(UserProfile::getEmail).forEach(extraBccs::remove);
+            ccs.stream().map(UserProfile::getEmail).forEach(extraBccs::remove);
+            bccs.stream().map(UserProfile::getEmail).forEach(extraBccs::remove);
+
+            tosByLocale = emailsByPreferredLocale(tos, validator, defLocale);
+            ccsByLocale = emailsByPreferredLocale(ccs, validator, defLocale);
+            bccsByLocale = emailsByPreferredLocale(bccs, validator, defLocale);
+            extraBccs = extraBccs.stream().filter(validator).collect(Collectors.toSet());
+            bccsByLocale.computeIfAbsent(message.getExtraBccsLocale(), k -> new HashSet<>()).addAll(extraBccs);
+        }
+
+        handlers = MimeMessageHandler.create(tosByLocale, ccsByLocale, bccsByLocale);
+        valids =
+                Stream.of(tosByLocale, ccsByLocale, bccsByLocale).flatMap(m -> m.values().stream()).mapToInt(Collection::size)
+                        .sum();
+
+        invalids.stream().forEach(blacklist::addInvalidAddress);
+
+        return new LocalEmailMessageDispatchReport(handlers, valids, invalids.size());
+    }
+
+    private static Map<Locale, Set<String>> emailsByPreferredLocale(Set<UserProfile> users, Predicate<String> emailValidator,
+            Locale defLocale) {
+        Map<Locale, Set<String>> emails = new HashMap<>();
+        users.stream().filter(p -> emailValidator.test(p.getEmail())).forEach(p -> {
+            Locale prefLocale = p.getPreferredLocale();
+            emails.computeIfAbsent(prefLocale != null ? prefLocale : defLocale, k -> new HashSet<>()).add(p.getEmail());
+        });
+        return emails;
+    }
+
+    private static Set<UserProfile> getProfiles(Set<Group> groups) {
+        return groups.stream().flatMap(g -> g.getMembers().stream()).map(User::getProfile).filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
     @Override
     public void delete() {
         setQueue(null);
-        for (MimeMessageHandler handler : getHandlerSet()) {
-            handler.delete();
-        }
+        getHandlerSet().forEach(MimeMessageHandler::delete);
         super.delete();
-    }
-
-    public static LocalEmailMessageDispatchReport dispatch(Message message) {
-        List<String> invalids = new ArrayList<String>();
-        Predicate<String> countingBlackListValidator = email -> {
-            if (isValid(email)) {
-                return true;
-            }
-            invalids.add(email);
-            EmailBlacklist.getInstance().addInvalidAddress(email);
-            return false;
-        };
-        Map<Locale, Set<String>> tos = message.getTosByLocale(countingBlackListValidator);
-        Map<Locale, Set<String>> ccs = message.getCcsByLocale(countingBlackListValidator);
-        Map<Locale, Set<String>> bccs = message.getBccsByLocale(countingBlackListValidator);
-
-        return new LocalEmailMessageDispatchReport(MimeMessageHandler.create(tos, ccs, bccs), tos.size() + ccs.size()
-                + bccs.size(), invalids.size());
-    }
-
-    private static boolean isValid(String email) {
-        if ((email == null) || (email.length() == 0)) {
-            return false;
-        }
-
-        if (email.indexOf(' ') > 0) {
-            return false;
-        }
-
-        String[] atSplit = email.split("@");
-        if (atSplit.length != 2) {
-            return false;
-        } else if ((atSplit[0].length() == 0) || (atSplit[1].length() == 0)) {
-            return false;
-        }
-
-        String domain = new String(atSplit[1]);
-
-        if (domain.lastIndexOf('.') == (domain.length() - 1)) {
-            return false;
-        }
-
-        if (domain.indexOf('.') <= 0) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/domain/MimeMessageHandler.java
+++ b/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/domain/MimeMessageHandler.java
@@ -1,16 +1,19 @@
 package org.fenixedu.messaging.emaildispatch.domain;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.mail.Address;
 import javax.mail.BodyPart;
+import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
 import javax.mail.SendFailedException;
 import javax.mail.Session;
@@ -19,11 +22,11 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMessage.RecipientType;
 import javax.mail.internet.MimeMultipart;
 
 import org.fenixedu.commons.i18n.LocalizedString;
 import org.fenixedu.messaging.domain.Message;
+import org.fenixedu.messaging.domain.MessagingSystem;
 import org.fenixedu.messaging.domain.Sender;
 import org.fenixedu.messaging.emaildispatch.EmailDispatchConfiguration;
 import org.fenixedu.messaging.emaildispatch.EmailDispatchConfiguration.ConfigurationProperties;
@@ -32,10 +35,8 @@ import org.joda.time.DateTime;
 import pt.ist.fenixframework.Atomic;
 import pt.ist.fenixframework.Atomic.TxMode;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 public final class MimeMessageHandler extends MimeMessageHandler_Base {
     private static final int MAX_RECIPIENTS = EmailDispatchConfiguration.getConfiguration().mailSenderMaxRecipients();
@@ -55,42 +56,31 @@ public final class MimeMessageHandler extends MimeMessageHandler_Base {
         return SESSION;
     }
 
-    protected MimeMessageHandler(Locale locale, List<String> tos, List<String> ccs, List<String> bccs) {
+    protected MimeMessageHandler(Locale locale, Collection<String> tos, Collection<String> ccs, Collection<String> bccs) {
         super();
         setLocale(locale);
         if (tos != null) {
-            setToAddresses(Joiner.on(", ").join(tos));
+            setToAddresses(MessagingSystem.Util.toEmailListString(tos));
         }
         if (ccs != null) {
-            setCcAddresses(Joiner.on(", ").join(ccs));
+            setCcAddresses(MessagingSystem.Util.toEmailListString(ccs));
         }
         if (bccs != null) {
-            setBccAddresses(Joiner.on(", ").join(bccs));
+            setBccAddresses(MessagingSystem.Util.toEmailListString(bccs));
         }
     }
 
-    public String getFrom() {
+    protected String getFrom() {
         Sender sender = getReport().getMessage().getSender();
         String name = sender.getFromName();
         String from = sender.getFromAddress();
         return Strings.isNullOrEmpty(name) ? from : name.replace(',', ' ').trim() + " <" + from + ">";
     }
 
-    public Set<String> getTos() {
-        return getToAddresses() != null ? Sets.newHashSet(getToAddresses().trim().split("\\s*,\\s*")) : Collections.emptySet();
-    }
-
-    public Set<String> getCcs() {
-        return getCcAddresses() != null ? Sets.newHashSet(getCcAddresses().trim().split("\\s*,\\s*")) : Collections.emptySet();
-    }
-
-    public Set<String> getBccs() {
-        return getBccAddresses() != null ? Sets.newHashSet(getBccAddresses().trim().split("\\s*,\\s*")) : Collections.emptySet();
-    }
-
-    public MimeMessage mimeMessage() throws AddressException, MessagingException {
+    protected MimeMessage mimeMessage() throws AddressException, MessagingException {
         Message message = getReport().getMessage();
         Locale locale = getLocale();
+        String[] languages = { locale.toLanguageTag() };
         MimeMessage mimeMessage = new MimeMessage(session()) {
             private String fenixMessageId = null;
 
@@ -111,6 +101,9 @@ public final class MimeMessageHandler extends MimeMessageHandler_Base {
 
         InternetAddress fromAddr = new InternetAddress(getFrom());
         mimeMessage.setFrom(fromAddr);
+
+        mimeMessage.setContentLanguage(languages);
+
         mimeMessage.setSubject(getContent(message.getSubject(), locale));
 
         String replyTo = message.getReplyTo();
@@ -124,7 +117,6 @@ public final class MimeMessageHandler extends MimeMessageHandler_Base {
         final String htmlBody = getContent(message.getHtmlBody(), locale);
         if (htmlBody != null && !htmlBody.trim().isEmpty()) {
             final BodyPart bodyPart = new MimeBodyPart();
-//            bodyPart.setContent(htmlBody, "text/html; charset='utf-8'");
             bodyPart.setContent(htmlBody, "text/html");
             mimeMultipart.addBodyPart(bodyPart);
         }
@@ -138,19 +130,23 @@ public final class MimeMessageHandler extends MimeMessageHandler_Base {
 
         mimeMessage.setContent(mimeMultipart);
 
-        for (String email : getTos()) {
-            mimeMessage.addRecipient(RecipientType.TO, new InternetAddress(email));
+        String addresses = getToAddresses();
+        if (addresses != null) {
+            mimeMessage.addRecipients(RecipientType.TO, addresses);
         }
-        for (String email : getCcs()) {
-            mimeMessage.addRecipient(RecipientType.CC, new InternetAddress(email));
+        addresses = getCcAddresses();
+        if (addresses != null) {
+            mimeMessage.addRecipients(RecipientType.CC, addresses);
         }
-        for (String email : getBccs()) {
-            mimeMessage.addRecipient(RecipientType.BCC, new InternetAddress(email));
+        addresses = getBccAddresses();
+        if (addresses != null) {
+            mimeMessage.addRecipients(RecipientType.BCC, addresses);
         }
+
         return mimeMessage;
     }
 
-    private String getContent(LocalizedString ls, Locale l) {
+    private static String getContent(LocalizedString ls, Locale l) {
         if (ls != null) {
             String s = ls.getContent(l);
             if (s == null) {
@@ -161,53 +157,88 @@ public final class MimeMessageHandler extends MimeMessageHandler_Base {
         return null;
     }
 
-    public static Set<MimeMessageHandler> create(Map<Locale, Set<String>> tos, Map<Locale, Set<String>> ccs,
+    public static Collection<MimeMessageHandler> create(Map<Locale, Set<String>> tos, Map<Locale, Set<String>> ccs,
             Map<Locale, Set<String>> bccs) {
-        Set<MimeMessageHandler> handlers = new HashSet<>();
-        for (Map.Entry<Locale, Set<String>> entry : tos.entrySet()) {
-            for (List<String> toChunk : Lists.partition(new ArrayList<String>(entry.getValue()), MAX_RECIPIENTS)) {
-                handlers.add(new MimeMessageHandler(entry.getKey(), toChunk, null, null));
-            }
-        }
-        for (Map.Entry<Locale, Set<String>> entry : ccs.entrySet()) {
-            for (List<String> ccChunk : Lists.partition(new ArrayList<String>(entry.getValue()), MAX_RECIPIENTS)) {
-                handlers.add(new MimeMessageHandler(entry.getKey(), null, ccChunk, null));
-            }
-        }
-        for (Map.Entry<Locale, Set<String>> entry : bccs.entrySet()) {
-            for (List<String> bccChunk : Lists.partition(new ArrayList<String>(entry.getValue()), MAX_RECIPIENTS)) {
-                handlers.add(new MimeMessageHandler(entry.getKey(), null, null, bccChunk));
-            }
-        }
-        return handlers;
+        return Stream.of(tos, ccs, bccs).flatMap(m -> m.keySet().stream()).distinct()
+                .flatMap(locale -> bestEffortCreate(locale, tos.get(locale), ccs.get(locale), bccs.get(locale)).stream())
+                .collect(Collectors.toSet());
     }
 
-    public static Set<MimeMessageHandler> create(Locale locale, List<String> tos, List<String> ccs, List<String> bccs) {
-        Set<MimeMessageHandler> handlers = new HashSet<>();
-        for (List<String> toChunk : Lists.partition(tos, MAX_RECIPIENTS)) {
-            handlers.add(new MimeMessageHandler(locale, toChunk, null, null));
+    /*XXX Best effort minimizes number of mime messages using a moving window. This approach also allows to group Tos and Ccs so
+     * that, in the most common case where there is an overflow of Bccs, at least the Tos and Ccs will be visible to each other.
+     * Note however that this intent is somewhat wasted when there are multiple preferred locales among Tos and Ccs due to the
+     * locale separation */
+    private static Collection<MimeMessageHandler> bestEffortCreate(Locale locale, Collection<String> tos, Collection<String> ccs,
+            Collection<String> bccs) {
+        Collection<MimeMessageHandler> handlers = new ArrayList<>();
+        List<String> all =
+                Stream.of(tos, ccs, bccs).filter(Objects::nonNull).flatMap(Collection::stream).collect(Collectors.toList()), partial;
+        List<List<String>> split = Lists.partition(all, MAX_RECIPIENTS);
+        MimeMessageHandler handler;
+
+        int nHandlers = split.size(), nRecipients = all.size(), nTos = tos != null ? tos.size() : 0, nCcs =
+                ccs != null ? ccs.size() : 0, nVisible = nTos + nCcs;
+        int ccStart, bccStart, mixedTos = nTos % MAX_RECIPIENTS, mixedVisible = nVisible % MAX_RECIPIENTS;
+        if (nTos == nRecipients && mixedTos != 0) {
+            ccStart = bccStart = nHandlers;
+        } else if (nVisible == nRecipients && mixedVisible != 0) {
+            ccStart = nTos / MAX_RECIPIENTS;
+            bccStart = nHandlers;
+        } else {
+            ccStart = nTos / MAX_RECIPIENTS;
+            bccStart = nVisible / MAX_RECIPIENTS;
         }
-        for (List<String> ccChunk : Lists.partition(ccs, MAX_RECIPIENTS)) {
-            handlers.add(new MimeMessageHandler(locale, null, ccChunk, null));
+
+        int i;
+        for (i = 0; i < ccStart; i++) { // Tos only
+            handlers.add(new MimeMessageHandler(locale, split.get(i), null, null));
         }
-        for (List<String> bccChunk : Lists.partition(bccs, MAX_RECIPIENTS)) {
-            handlers.add(new MimeMessageHandler(locale, null, null, bccChunk));
+        if (i < nHandlers && mixedTos != 0) {
+            partial = split.get(i);
+            if (nCcs == 0) { //Tos along with Bccs
+                handler =
+                        new MimeMessageHandler(locale, partial.subList(0, mixedTos), null, partial.subList(mixedTos,
+                                partial.size()));
+            } else if (ccStart == bccStart) {// Tos along with Ccs and Bccs
+                handler =
+                        new MimeMessageHandler(locale, partial.subList(0, mixedTos), partial.subList(mixedTos, mixedVisible),
+                                partial.subList(mixedVisible, partial.size()));
+            } else { // Tos along with Ccs
+                handler =
+                        new MimeMessageHandler(locale, partial.subList(0, mixedTos), partial.subList(mixedTos, partial.size()),
+                                null);
+            }
+            handlers.add(handler);
+            i++;
+        }
+        for (; i < bccStart; i++) { // Ccs only
+            handlers.add(new MimeMessageHandler(locale, null, split.get(i), null));
+        }
+        if (i < nHandlers && mixedVisible != 0 && ccStart != bccStart) { // Ccs along with Bccs
+            partial = split.get(i);
+            handlers.add(new MimeMessageHandler(locale, null, partial.subList(0, mixedVisible), partial.subList(mixedVisible,
+                    partial.size())));
+            i++;
+        }
+        for (; i < nHandlers; i++) { // Bccs only
+            handlers.add(new MimeMessageHandler(locale, null, null, split.get(i)));
         }
         return handlers;
     }
 
     @Atomic(mode = TxMode.WRITE)
     public void deliver() throws MessagingException {
+        LocalEmailMessageDispatchReport report = getReport();
         try {
             MimeMessage message = mimeMessage();
             Transport.send(message);
-            getReport().setDeliveredCount(getReport().getDeliveredCount() + message.getAllRecipients().length);
+            report.setDeliveredCount(report.getDeliveredCount() + message.getAllRecipients().length);
         } catch (SendFailedException e) {
             if (e.getValidSentAddresses() != null) {
-                getReport().setDeliveredCount(getReport().getDeliveredCount() + e.getValidSentAddresses().length);
+                report.setDeliveredCount(report.getDeliveredCount() + e.getValidSentAddresses().length);
             }
             if (e.getInvalidAddresses() != null) {
-                getReport().setFailedCount(getReport().getFailedCount() + e.getInvalidAddresses().length);
+                report.setFailedCount(report.getFailedCount() + e.getInvalidAddresses().length);
                 for (Address failed : e.getInvalidAddresses()) {
                     EmailBlacklist.getInstance().addFailedAddress(failed.toString());
                 }
@@ -220,26 +251,21 @@ public final class MimeMessageHandler extends MimeMessageHandler_Base {
     }
 
     private void resend(Address[] validUnsentAddresses) {
-        Set<String> currentTos = getTos();
-        Set<String> currentCcs = getCcs();
-        Set<String> currentBccs = getBccs();
-        List<String> tos = new ArrayList<>();
-        List<String> ccs = new ArrayList<>();
-        List<String> bccs = new ArrayList<>();
-        for (Address email : validUnsentAddresses) {
-            if (currentTos.contains(email.toString())) {
-                tos.add(email.toString());
-            }
-            if (currentCcs.contains(email.toString())) {
-                ccs.add(email.toString());
-            }
-            if (currentBccs.contains(email.toString())) {
-                bccs.add(email.toString());
-            }
-        }
-        for (MimeMessageHandler handler : MimeMessageHandler.create(getLocale(), tos, ccs, bccs)) {
-            getReport().addHandler(handler);
-        }
+        Set<String> currentTos = MessagingSystem.Util.toEmailSet(getToAddresses());
+        Set<String> currentCcs = MessagingSystem.Util.toEmailSet(getCcAddresses());
+        Map<RecipientType, List<String>> unsent =
+                Stream.of(validUnsentAddresses).map(Address::toString).collect(Collectors.groupingBy(e -> {
+                    if (currentTos.contains(e)) {
+                        return RecipientType.TO;
+                    } else if (currentCcs.contains(e)) {
+                        return RecipientType.CC;
+                    } else {
+                        return RecipientType.BCC;
+                    }
+                }));
+        getReport().addHandler(
+                new MimeMessageHandler(getLocale(), unsent.get(RecipientType.TO), unsent.get(RecipientType.CC), unsent
+                        .get(RecipientType.BCC)));
     }
 
     public void delete() {


### PR DESCRIPTION
make email validation and handling consistent
relocate locale separation logic from Message to dispatch implementation
improve mime message creation and address distribution in email-dispatch
introduce a bcc only option in email-dispatch
fix bug: ccs provided as bccs when separating by locale
fix bug: erroneous total delivery count in the report
fix bug: missing newline in wrapper template