### PR TITLE
Force Bennu 4 version through a direct dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
         <dependency>
             <groupId>org.fenixedu</groupId>
+            <artifactId>bennu-core</artifactId>
+            <version>${version.org.fenixedu.bennu}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.fenixedu</groupId>
             <artifactId>bennu-portal</artifactId>
             <version>${version.org.fenixedu.bennu}</version>
         </dependency>

--- a/core/src/main/java/org/fenixedu/messaging/bootstrap/MessagingSystemBootstrap.java
+++ b/core/src/main/java/org/fenixedu/messaging/bootstrap/MessagingSystemBootstrap.java
@@ -10,7 +10,6 @@ import org.fenixedu.bennu.core.bootstrap.annotations.Field;
 import org.fenixedu.bennu.core.bootstrap.annotations.FieldType;
 import org.fenixedu.bennu.core.bootstrap.annotations.Section;
 import org.fenixedu.bennu.core.domain.exceptions.BennuCoreDomainException;
-import org.fenixedu.bennu.core.groups.AnyoneGroup;
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.messaging.bootstrap.MessagingSystemBootstrap.SystemSenderSection;
 import org.fenixedu.messaging.domain.MessageDeletionPolicy;
@@ -59,7 +58,7 @@ public class MessagingSystemBootstrap {
             sender.setAddress(address);
             sender.setMembers(group);
             sender.setPolicy(MessageDeletionPolicy.unlimited());
-            sender.addRecipient(AnyoneGroup.get());
+            sender.addRecipient(Group.anyone());
         }
         return errors;
     }

--- a/core/src/main/java/org/fenixedu/messaging/domain/MessagingSystem.java
+++ b/core/src/main/java/org/fenixedu/messaging/domain/MessagingSystem.java
@@ -111,7 +111,7 @@ public class MessagingSystem extends MessagingSystem_Base {
         }
 
         public static Set<String> toEmailSet(Collection<PersistentGroup> groups) {
-            return groups.stream().flatMap(g -> g.getMembers().stream()).map(User::getProfile).filter(Objects::nonNull)
+            return groups.stream().flatMap(g -> g.getMembers()).map(User::getProfile).filter(Objects::nonNull)
                     .map(UserProfile::getEmail).filter(e -> !Strings.isNullOrEmpty(e)).collect(Collectors.toSet());
         }
 

--- a/core/src/main/java/org/fenixedu/messaging/domain/Sender.java
+++ b/core/src/main/java/org/fenixedu/messaging/domain/Sender.java
@@ -36,7 +36,6 @@ import java.util.stream.Stream;
 import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.domain.groups.PersistentGroup;
 import org.fenixedu.bennu.core.groups.Group;
-import org.fenixedu.bennu.core.groups.NobodyGroup;
 import org.fenixedu.bennu.core.security.Authenticate;
 import org.fenixedu.messaging.exception.MessagingDomainException;
 import org.joda.time.Period;
@@ -62,7 +61,7 @@ public class Sender extends Sender_Base implements Comparable<Sender> {
     public static final class SenderBuilder {
         private String address, name = null, replyTo = null;
         private boolean htmlEnabled = false;
-        private Group members = NobodyGroup.get();
+        private Group members = Group.nobody();
         private MessageDeletionPolicy policy = MessageDeletionPolicy.unlimited();
         private Set<Group> recipients = new HashSet<>();
 
@@ -89,12 +88,12 @@ public class Sender extends Sender_Base implements Comparable<Sender> {
         }
 
         public SenderBuilder members(Group members) {
-            this.members = members != null ? members : NobodyGroup.get();
+            this.members = members != null ? members : Group.nobody();
             return this;
         }
 
         public SenderBuilder members(PersistentGroup members) {
-            this.members = members != null ? members.toGroup() : NobodyGroup.get();
+            this.members = members != null ? members.toGroup() : Group.nobody();
             return this;
         }
 

--- a/email-dispatch/pom.xml
+++ b/email-dispatch/pom.xml
@@ -29,6 +29,11 @@
             <version>${version.org.fenixedu.bennu-renderers}</version>
         </dependency>
         <dependency>
+            <groupId>org.fenixedu</groupId>
+            <artifactId>bennu-core</artifactId>
+            <version>${version.org.fenixedu.bennu}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
             <version>${version.javax.mail.mail}</version>

--- a/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/domain/LocalEmailMessageDispatchReport.java
+++ b/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/domain/LocalEmailMessageDispatchReport.java
@@ -141,7 +141,7 @@ public class LocalEmailMessageDispatchReport extends LocalEmailMessageDispatchRe
     }
 
     private static Set<UserProfile> getProfiles(Set<Group> groups) {
-        return groups.stream().flatMap(g -> g.getMembers().stream()).map(User::getProfile).filter(Objects::nonNull)
+        return groups.stream().flatMap(g -> g.getMembers()).map(User::getProfile).filter(Objects::nonNull)
                 .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
Bennu 4 dependency would be otherwise omitted in favor of Bennu Renderer's dependency version (3.4.0)