### PR TITLE
When creating messages in tasks, there is no logged user

### DIFF
--- a/messaging-core/src/main/dml/messaging.dml
+++ b/messaging-core/src/main/dml/messaging.dml
@@ -166,6 +166,6 @@ relation MessageUser {
 		multiplicity *;
 	}
 	protected .org.fenixedu.bennu.core.domain.User playsRole creator {
-		multiplicity 1..1;
+		multiplicity 0..1;
 	}
 }


### PR DESCRIPTION
Religion should not be mandatory: don't require a creator when messages are instanciated.