### PR TITLE
NPE when viewing message details FMSG-10 #resolve

### DIFF
--- a/messaging-core/src/main/java/org/fenixedu/messaging/core/domain/Message.java
+++ b/messaging-core/src/main/java/org/fenixedu/messaging/core/domain/Message.java
@@ -446,7 +446,10 @@ public final class Message extends Message_Base implements Comparable<Message> {
     }
 
     public boolean isDeletable() {
-        return getCreator().equals(Authenticate.getUser()) && getDispatchReport() == null;
+        if (getCreator() != null) {
+            return getCreator().equals(Authenticate.getUser()) && getDispatchReport() == null;
+        }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Since #58, creator is no longer mandatory which means it can be null.