### PR TITLE
Improve sender search to be locale insensitive FMSG-55 #resolve

### DIFF
--- a/messaging-core/src/main/java/org/fenixedu/messaging/core/domain/Sender.java
+++ b/messaging-core/src/main/java/org/fenixedu/messaging/core/domain/Sender.java
@@ -57,8 +57,6 @@ import static org.fenixedu.messaging.core.domain.MessagingSystem.Util.isValidEma
  */
 public class Sender extends Sender_Base implements Comparable<Sender> {
 
-    private static Collator ptCollator = Collator.getInstance(Locale.forLanguageTag("pt"));
-
     protected Sender() {
         super();
         setMessagingSystem(MessagingSystem.getInstance());
@@ -305,7 +303,7 @@ public class Sender extends Sender_Base implements Comparable<Sender> {
 
     @Override
     public int compareTo(Sender sender) {
-        int c = ptCollator.compare(getName(), sender.getName());
+        int c = Collator.getInstance(Locale.ROOT).compare(getName(),sender.getName());
         return c == 0 ? getExternalId().compareTo(sender.getExternalId()) : c;
     }
 }

--- a/messaging-core/src/main/java/org/fenixedu/messaging/core/ui/MessagingController.java
+++ b/messaging-core/src/main/java/org/fenixedu/messaging/core/ui/MessagingController.java
@@ -24,16 +24,9 @@
  */
 package org.fenixedu.messaging.core.ui;
 
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.google.common.base.Strings;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import org.fenixedu.bennu.core.security.Authenticate;
 import org.fenixedu.bennu.core.util.CoreConfiguration;
@@ -45,7 +38,6 @@ import org.fenixedu.messaging.core.domain.Message;
 import org.fenixedu.messaging.core.domain.MessageFile;
 import org.fenixedu.messaging.core.domain.Sender;
 import org.fenixedu.messaging.core.exception.MessagingDomainException;
-import org.joda.time.DateTime;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -61,10 +53,14 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.view.RedirectView;
 
-
-import com.google.gson.JsonObject;
-
 import javax.servlet.http.HttpServletRequest;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static pt.ist.fenixframework.FenixFramework.atomic;
 
@@ -83,7 +79,7 @@ public class MessagingController {
             @RequestParam(value = "items", defaultValue = "10") final int items,
             @RequestParam(value = "search", defaultValue = "") final String search) {
         Set<Sender> senders = Sender.available().stream()
-                .filter(sender -> sender.getName().toLowerCase().contains(search.toLowerCase()))
+                .filter(sender -> sender.getName().toLowerCase(Locale.ROOT).contains(search.toLowerCase(Locale.ROOT)))
                 .collect(Collectors.toSet());
         PaginationUtils.paginate(model, "messaging/senders", "senders", senders, Comparator.comparing(Sender::getLastMessageSentDate).reversed(), items, page);
         model.addAttribute("search", search);

--- a/messaging-core/src/main/java/org/fenixedu/messaging/core/ui/SenderConfigController.java
+++ b/messaging-core/src/main/java/org/fenixedu/messaging/core/ui/SenderConfigController.java
@@ -1,14 +1,10 @@
 package org.fenixedu.messaging.core.ui;
 
-import java.util.Collection;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import com.google.common.collect.ImmutableMap;
 import org.fenixedu.bennu.spring.portal.SpringFunctionality;
 import org.fenixedu.messaging.core.domain.MessagingSystem;
 import org.fenixedu.messaging.core.domain.Sender;
 import org.fenixedu.messaging.core.exception.MessagingDomainException;
-import org.springframework.http.MediaType;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,7 +14,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static pt.ist.fenixframework.FenixFramework.atomic;
 
@@ -40,7 +39,7 @@ public class SenderConfigController {
         model.addAttribute("sender", systemSender);
         model.addAttribute("system", true);
         Set<Sender> senderSet = Sender.all().stream()
-                .filter(s -> s.getName().toLowerCase().contains(search.toLowerCase()))
+                .filter(s -> s.getName().toLowerCase(Locale.ROOT).contains(search.toLowerCase(Locale.ROOT)))
                 .collect(Collectors.toSet());
         senderSet.remove(systemSender);
         PaginationUtils.paginate(model, "messaging/config/senders", "senders", senderSet, items, page);


### PR DESCRIPTION
According to JDK javadocs, Locale.ROOT should be used to support locale insensitive comparison/lowercase operations.

References:
https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#toLowerCase--
https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#ROOT
