### PR TITLE
Unable to finish delivering emails due to failed addresses FMSG-58 #resolve

### DIFF
--- a/email-dispatch/pom.xml
+++ b/email-dispatch/pom.xml
@@ -11,7 +11,7 @@
     <name>Email Dispatcher</name>
 
     <properties>
-        <version.javax.mail.javax.mail-api>1.6.0</version.javax.mail.javax.mail-api>
+        <version.javax.mail>1.6.0</version.javax.mail>
     </properties>
 
     <dependencies>
@@ -23,7 +23,13 @@
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>javax.mail-api</artifactId>
-            <version>${version.javax.mail.javax.mail-api}</version>
+            <version>${version.javax.mail}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
+            <version>${version.javax.mail}</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/domain/EmailBlacklist.java
+++ b/email-dispatch/src/main/java/org/fenixedu/messaging/emaildispatch/domain/EmailBlacklist.java
@@ -1,5 +1,6 @@
 package org.fenixedu.messaging.emaildispatch.domain;
 
+import com.google.common.base.Strings;
 import pt.ist.fenixframework.Atomic;
 import pt.ist.fenixframework.Atomic.TxMode;
 
@@ -50,13 +51,17 @@ public class EmailBlacklist extends EmailBlacklist_Base {
     }
 
     public void addInvalidAddress(String invalid) {
-        log(invalid, STATUS_INVALID);
-        logger.warn("Blacklisting email {} because is invalid", invalid);
+        if (!Strings.isNullOrEmpty(invalid)) {
+            log(invalid, STATUS_INVALID);
+            logger.warn("Blacklisting email {} because is invalid", invalid);
+        }
     }
 
     public void addFailedAddress(String failed) {
-        log(failed, STATUS_FAILED);
-        logger.warn("Blacklisting email {} because it failed a deliver", failed);
+        if (!Strings.isNullOrEmpty(failed)) {
+            log(failed, STATUS_FAILED);
+            logger.warn("Blacklisting email {} because it failed a deliver", failed);
+        }
     }
 
     public void pruneOldLogs(DateTime before) {


### PR DESCRIPTION
We need to follow the exception chain to find the addresses that caused the SendFailedException to be thrown and filter those out of valid unsent addresses for resending.
